### PR TITLE
Parallel data representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Tak-sum WONG, Kim GERDES, Herman LEUNG, and John LEE. "Quantitative Comparative 
 
 # Changelog
 
+* 2025-09-12 v2.16
+  * add parallel corpus information to machine-readable metadata
+  * add parallel data support with parallel_id metadata
 * 2022-11-15 v2.11
   * Fixed validation errors.
   * Added lemmas where they were missing.
@@ -84,7 +87,7 @@ Data source: manual
 Data available since: UD v2.1
 License: CC BY-SA 4.0
 Includes text: yes
-Parallel: no
+Parallel: hk
 Genre: spoken
 Lemmas: automatic
 UPOS: manual native

--- a/yue_hk-ud-test.conllu
+++ b/yue_hk-ud-test.conllu
@@ -1,4 +1,5 @@
 # sent_id = 1
+# parallel_id = hk/1
 # text = 你喺度搵乜嘢呀？
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No|Translit=nei5|Gloss=2SG
 2	喺度	喺度	ADV	_	_	3	advmod	_	SpaceAfter=No|Translit=hai2dou6|Gloss=PROG
@@ -8,6 +9,7 @@
 6	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 2
+# parallel_id = hk/2
 # text = 咪執返啲嘢去阿哥個新屋度囖。
 1	咪	咪	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	執	執	VERB	_	_	0	root	_	SpaceAfter=No
@@ -24,6 +26,7 @@
 13	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 3
+# parallel_id = hk/3
 # text = 該拎嗰啲都拎走咗啦！
 1	該	該	AUX	_	_	2	aux	_	SpaceAfter=No
 2	拎	拎	VERB	_	_	3	acl	_	SpaceAfter=No
@@ -36,6 +39,7 @@
 9	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 4
+# parallel_id = hk/4
 # text = 剩落呢啲都係冇用㗎喇！
 1	剩	剩	VERB	_	_	3	acl	_	SpaceAfter=No
 2	落	落	PART	_	_	1	advmod	_	SpaceAfter=No
@@ -48,6 +52,7 @@
 9	！	！	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 5
+# parallel_id = hk/5
 # text = 噉都要執！
 1	噉	噉	ADV	_	_	4	discourse	_	SpaceAfter=No
 2	都	都	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -57,6 +62,7 @@
 6	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 6
+# parallel_id = hk/6
 # text = 係喇，豪仔今晚返唔返嚟食飯呀？
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	喇	嘑	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -71,6 +77,7 @@
 11	？	？	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 7
+# parallel_id = hk/7
 # text = 佢日日都同女朋友去玩煮飯仔，鬼得閒理我哋咩？
 1	佢	佢	PRON	_	_	6	nsubj	_	SpaceAfter=No
 2	日日	日日	ADV	_	_	6	advmod	_	SpaceAfter=No
@@ -89,6 +96,7 @@
 15	？	？	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 8
+# parallel_id = hk/8
 # text = 呢啲都唔要㗎啦，可？
 1	呢啲	呢啲	PRON	_	_	4	obj:periph	_	SpaceAfter=No
 2	都	都	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -101,6 +109,7 @@
 9	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 9
+# parallel_id = hk/9
 # text = 部機都冇咗嘞。
 1	部	部	NOUN	_	NounType=Clf	2	clf:det	_	SpaceAfter=No
 2	機	機	NOUN	_	_	4	nsubj	_	SpaceAfter=No
@@ -111,6 +120,7 @@
 7	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 10
+# parallel_id = hk/10
 # text = 爺爺，我可唔可以睇新一集嘅龍珠呀？
 1	爺爺	爺爺	NOUN	_	_	7	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -128,6 +138,7 @@
 14	？	？	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 11
+# parallel_id = hk/11
 # text = 等你媽咪收工返嚟，同你對晒啲功課先睇啦！
 1	等	等	VERB	_	_	14	advcl	_	SpaceAfter=No
 2	你	你	PRON	_	_	3	nmod	_	SpaceAfter=No
@@ -147,6 +158,7 @@
 16	！	！	PUNCT	_	_	14	punct	_	SpaceAfter=No
 
 # sent_id = 12
+# parallel_id = hk/12
 # text = 爺爺，我做晒功課喇！
 1	爺爺	爺爺	NOUN	_	_	4	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -158,12 +170,14 @@
 8	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 13
+# parallel_id = hk/13
 # text = 默書呢？
 1	默書	默書	VERB	_	_	0	root	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 14
+# parallel_id = hk/14
 # text = 冇呀，爺爺。
 1	冇	冇	VERB	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -172,11 +186,13 @@
 5	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 15
+# parallel_id = hk/15
 # text = 冇？
 1	冇	冇	VERB	_	_	0	root	_	SpaceAfter=No
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 16
+# parallel_id = hk/16
 # text = 爺爺，好好睇㗎！
 1	爺爺	爺爺	NOUN	_	_	4	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -186,6 +202,7 @@
 6	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 17
+# parallel_id = hk/17
 # text = 你⋯⋯同我睇啦！
 1	你	你	PRON	_	_	5	nsubj	_	SpaceAfter=No
 2	⋯⋯	⋯⋯	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -196,12 +213,14 @@
 7	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 18
+# parallel_id = hk/18
 # text = 唔睇。
 1	唔	唔	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	睇	睇	VERB	_	_	0	root	_	SpaceAfter=No
 3	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 19
+# parallel_id = hk/19
 # text = 我都唔睇呢啲公仔嘅。
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No
 2	都	都	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -213,6 +232,7 @@
 8	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 20
+# parallel_id = hk/20
 # text = 爺爺，你冇tei1si2嘅！
 1	爺爺	爺爺	NOUN	_	_	4	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -223,6 +243,7 @@
 7	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 21
+# parallel_id = hk/21
 # text = 好好睇㗎！
 1	好	好	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	好睇	好睇	ADJ	_	_	0	root	_	SpaceAfter=No
@@ -230,6 +251,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 22
+# parallel_id = hk/22
 # text = 舊陣時呢，龍珠係好興㗎。
 1	舊陣時	舊陣時	NOUN	_	_	7	obl:tmod	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -242,6 +264,7 @@
 9	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 23
+# parallel_id = hk/23
 # text = 成日都講埋啲咩龜波氣功吖，打交啦。
 1	成日	成日	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	都	都	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -257,6 +280,7 @@
 12	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 24
+# parallel_id = hk/24
 # text = 三歲到卅歲都沉迷。
 1	三	三	NUM	_	_	2	nummod	_	SpaceAfter=No
 2	歲	歲	NOUN	_	NounType=Clf	7	nsubj	_	SpaceAfter=No
@@ -268,6 +292,7 @@
 8	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 25
+# parallel_id = hk/25
 # text = 噓！好誇張呀。
 1	噓	噓	INTJ	_	_	4	discourse	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -277,6 +302,7 @@
 6	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 26
+# parallel_id = hk/26
 # text = 軒軒，走啦！
 1	軒軒	軒軒	PROPN	_	_	3	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -285,6 +311,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 27
+# parallel_id = hk/27
 # text = 走啦，走啦⋯⋯走啦，走啦。
 1	走	走	VERB	_	_	0	root	_	SpaceAfter=No
 2	啦	喇	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -300,6 +327,7 @@
 12	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 28
+# parallel_id = hk/28
 # text = 吖，掰掰啦，同小朋友掰掰。
 1	吖	吖	PART	_	_	3	discourse:sp	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	3	punct	_	SpaceAfter=No
@@ -312,11 +340,13 @@
 9	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 29
+# parallel_id = hk/29
 # text = 掰掰！
 1	掰掰	掰掰	VERB	_	_	0	root	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 30
+# parallel_id = hk/30
 # text = 爺爺，我行嘞！
 1	爺爺	爺爺	NOUN	_	_	4	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -326,6 +356,7 @@
 6	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 31
+# parallel_id = hk/31
 # text = 爺爺呀，快啲啦！
 1	爺爺	爺爺	NOUN	_	_	4	vocative	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -336,6 +367,7 @@
 7	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 32
+# parallel_id = hk/32
 # text = 行得未呀？
 1	行	行	VERB	_	_	0	root	_	SpaceAfter=No
 2	得	得	AUX	_	_	1	aux	_	SpaceAfter=No
@@ -344,6 +376,7 @@
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 33
+# parallel_id = hk/33
 # text = 得㗎啦，得㗎啦，係，呢度！好嘞！
 1	得	得	VERB	_	_	0	root	_	SpaceAfter=No
 2	㗎	㗎	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -362,11 +395,13 @@
 15	！	！	PUNCT	_	_	13	punct	_	SpaceAfter=No
 
 # sent_id = 34
+# parallel_id = hk/34
 # text = ＯＫ！
 1	ＯＫ	ＯＫ	VERB	_	_	0	root	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 35
+# parallel_id = hk/35
 # text = 得㗎喇！
 1	得	得	VERB	_	_	0	root	_	SpaceAfter=No
 2	㗎	㗎	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -374,6 +409,7 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 36
+# parallel_id = hk/36
 # text = 超級撒亞人！
 1	超級	超級	ADJ	_	_	3	amod	_	SpaceAfter=No
 2	撒亞	撒亞	PROPN	_	_	3	compound	_	SpaceAfter=No
@@ -381,6 +417,7 @@
 4	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 37
+# parallel_id = hk/37
 # text = 戰鬥力超勁！
 1	戰鬥力	戰鬥力	NOUN	_	_	3	nsubj	_	SpaceAfter=No
 2	超	超	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -388,6 +425,7 @@
 4	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 38
+# parallel_id = hk/38
 # text = 爺爺，我行得喇！
 1	爺爺	爺爺	NOUN	_	_	4	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -398,11 +436,13 @@
 7	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 39
+# parallel_id = hk/39
 # text = 多多！
 1	多多	多多	PROPN	_	_	0	root	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 40
+# parallel_id = hk/40
 # text = 你成日就知道多多！
 1	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No
 2	成日	成日	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -412,6 +452,7 @@
 6	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 41
+# parallel_id = hk/41
 # text = 唔好整呀！
 1	唔好	唔好	AUX	_	_	2	aux	_	SpaceAfter=No
 2	整	整	VERB	_	_	0	root	_	SpaceAfter=No
@@ -419,6 +460,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 42
+# parallel_id = hk/42
 # text = 整出嚟呀！
 1	整	整	VERB	_	_	0	root	_	SpaceAfter=No
 2	出嚟	出唻	VERB	_	_	1	compound:dir	_	SpaceAfter=No
@@ -426,12 +468,14 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 43
+# parallel_id = hk/43
 # text = 斤半！
 1	斤	斤	NOUN	_	NounType=Clf	0	root	_	SpaceAfter=No
 2	半	半	NUM	_	_	1	conj	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 44
+# parallel_id = hk/44
 # text = 好，收到。
 1	好	好	ADJ	_	_	0	root	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -440,6 +484,7 @@
 5	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 45
+# parallel_id = hk/45
 # text = 走啦，快啲！
 1	走	走	VERB	_	_	0	root	_	SpaceAfter=No
 2	啦	喇	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -449,6 +494,7 @@
 6	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 46
+# parallel_id = hk/46
 # text = 六十六個四。
 1	六十六	六十六	NUM	_	_	2	nummod	_	SpaceAfter=No
 2	個	個	NOUN	_	NounType=Clf	0	root	_	SpaceAfter=No
@@ -456,12 +502,14 @@
 4	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 47
+# parallel_id = hk/47
 # text = 幾多呀？
 1	幾多	幾多	PRON	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 48
+# parallel_id = hk/48
 # text = 六十六個四。
 1	六十六	六十六	NUM	_	_	2	nummod	_	SpaceAfter=No
 2	個	個	NOUN	_	NounType=Clf	0	root	_	SpaceAfter=No
@@ -469,11 +517,13 @@
 4	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 49
+# parallel_id = hk/49
 # text = 一百。
 1	一百	一百	NUM	_	_	0	root	_	SpaceAfter=No
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 50
+# parallel_id = hk/50
 # text = 找返你三十⋯⋯
 1	找	找	VERB	_	_	0	root	_	SpaceAfter=No
 2	返	返	VERB	_	_	1	compound:dir	_	SpaceAfter=No
@@ -482,6 +532,7 @@
 5	⋯⋯	⋯⋯	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 51
+# parallel_id = hk/51
 # text = 姐姐呀，啲錢畀我得㗎嘞！
 1	姐姐	姐姐	NOUN	_	_	8	vocative	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -496,6 +547,7 @@
 11	！	！	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 52
+# parallel_id = hk/52
 # text = 爺爺呀，呢啲畀你嘅！
 1	爺爺	爺爺	NOUN	_	_	5	vocative	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -507,12 +559,14 @@
 8	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 53
+# parallel_id = hk/53
 # text = 嗰啲呢？
 1	嗰啲	嗰啲	PRON	_	_	0	root	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 54
+# parallel_id = hk/54
 # text = 係我㗎！
 1	係	係	AUX	_	_	2	cop	_	SpaceAfter=No
 2	我	我	PRON	_	_	0	root	_	SpaceAfter=No
@@ -520,6 +574,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 55
+# parallel_id = hk/55
 # text = 佢成日話，冇龍珠閃卡，喺學校就冇朋友。
 1	佢	佢	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	成日	成日	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -537,6 +592,7 @@
 14	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 56
+# parallel_id = hk/56
 # text = 唏！都唔知關咩事。
 1	唏	唏	INTJ	_	_	5	discourse	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No
@@ -549,6 +605,7 @@
 9	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 57
+# parallel_id = hk/57
 # text = 係佢冇運啫。
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	佢	佢	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -558,11 +615,13 @@
 6	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 58
+# parallel_id = hk/58
 # text = 媽咪！
 1	媽咪	媽咪	NOUN	_	_	0	root	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 59
+# parallel_id = hk/59
 # text = 咩事呀？
 1	咩	咩	DET	_	_	2	det	_	SpaceAfter=No
 2	事	事	NOUN	_	_	0	root	_	SpaceAfter=No
@@ -570,6 +629,7 @@
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 60
+# parallel_id = hk/60
 # text = 我默書一百分呀。
 1	我	我	PRON	_	_	4	dislocated	_	SpaceAfter=No
 2	默書	默書	VERB	_	_	4	dislocated	_	SpaceAfter=No
@@ -579,6 +639,7 @@
 6	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 61
+# parallel_id = hk/61
 # text = 畀我睇下。
 1	畀	畀	VERB	_	_	0	root	_	SpaceAfter=No
 2	我	我	PRON	_	_	1	nsubj	_	SpaceAfter=No
@@ -587,6 +648,7 @@
 5	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 62
+# parallel_id = hk/62
 # text = 嘩！真係喎！好叻喎！
 1	嘩	嘩	INTJ	_	_	3	discourse	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -599,6 +661,7 @@
 9	！	！	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 63
+# parallel_id = hk/63
 # text = 好啦！媽咪聽日煮雞翼獎勵你啦，好唔好？
 1	好	好	ADJ	_	_	0	root	_	SpaceAfter=No
 2	啦	喇	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -617,6 +680,7 @@
 15	？	？	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 64
+# parallel_id = hk/64
 # text = 我唔食雞翼嘞，我要零用錢呀。
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -631,6 +695,7 @@
 11	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 65
+# parallel_id = hk/65
 # text = 噉好啦，媽咪去攞畀你啦，好唔好？
 1	噉	噉	ADV	_	_	2	discourse	_	SpaceAfter=No
 2	好	好	ADJ	_	_	0	root	_	SpaceAfter=No
@@ -649,6 +714,7 @@
 15	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 66
+# parallel_id = hk/66
 # text = 乖乖地，唔好搞搞震呀！
 1	乖乖地	乖乖地	ADV	_	_	4	advmod	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	4	punct	_	SpaceAfter=No
@@ -658,6 +724,7 @@
 6	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 67
+# parallel_id = hk/67
 # text = 你洗手未呀？
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	洗	洗	VERB	_	_	0	root	_	SpaceAfter=No
@@ -667,6 +734,7 @@
 6	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 68
+# parallel_id = hk/68
 # text = 洗咗嘞！
 1	洗	洗	VERB	_	_	0	root	_	SpaceAfter=No
 2	咗	咗	AUX	_	_	1	aux	_	SpaceAfter=No
@@ -674,6 +742,7 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 69
+# parallel_id = hk/69
 # text = 算你啦！
 1	算	算	VERB	_	_	0	root	_	SpaceAfter=No
 2	你	你	PRON	_	_	1	obj	_	SpaceAfter=No
@@ -681,6 +750,7 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 70
+# parallel_id = hk/70
 # text = 乖乖地要畀心機讀書呀，知唔知呀，繼續？
 1	乖乖地	乖乖地	ADV	_	_	5	advmod	_	SpaceAfter=No
 2	要	要	AUX	_	_	5	aux	_	SpaceAfter=No
@@ -698,12 +768,14 @@
 14	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 71
+# parallel_id = hk/71
 # text = 知道嘞。
 1	知道	知道	VERB	_	_	0	root	_	SpaceAfter=No
 2	嘞	嘞	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 72
+# parallel_id = hk/72
 # text = 快啲做功課啦。
 1	快	快	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	啲	啲	ADV	_	_	1	advmod	_	SpaceAfter=No
@@ -713,6 +785,7 @@
 6	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 73
+# parallel_id = hk/73
 # text = 唔該！十個一蚊！
 1	唔該	唔該	VERB	_	_	0	root	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -723,6 +796,7 @@
 7	！	！	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 74
+# parallel_id = hk/74
 # text = 十個一蚊。
 1	十	十	NUM	_	_	4	nummod	_	SpaceAfter=No
 2	個	個	NOUN	_	NounType=Clf	1	clf	_	SpaceAfter=No
@@ -731,12 +805,14 @@
 5	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 75
+# parallel_id = hk/75
 # text = 唔該晒！
 1	唔該	唔該	VERB	_	_	0	root	_	SpaceAfter=No
 2	晒	晒	PART	_	_	1	advmod	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 76
+# parallel_id = hk/76
 # text = 換咗呀？
 1	換	換	VERB	_	_	0	root	_	SpaceAfter=No
 2	咗	咗	AUX	_	_	1	aux	_	SpaceAfter=No
@@ -744,6 +820,7 @@
 4	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 77
+# parallel_id = hk/77
 # text = 好好彩喎！
 1	好	好	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	好彩	好彩	ADJ	_	_	0	root	_	SpaceAfter=No
@@ -751,6 +828,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 78
+# parallel_id = hk/78
 # text = 呢張唔係你中意嘅孫悟空咩？
 1	呢	呢	DET	_	_	2	det	_	SpaceAfter=No
 2	張	張	NOUN	_	NounType=Clf	8	nsubj	_	SpaceAfter=No
@@ -764,6 +842,7 @@
 10	？	？	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 79
+# parallel_id = hk/79
 # text = 都唔閃嘅！
 1	都	都	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -772,6 +851,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 80
+# parallel_id = hk/80
 # text = 走啦，返屋企啦！
 1	走	走	VERB	_	_	0	root	_	SpaceAfter=No
 2	啦	喇	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -782,6 +862,7 @@
 7	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 81
+# parallel_id = hk/81
 # text = 擰晒㗎喇！
 1	擰	擰	VERB	_	_	0	root	_	SpaceAfter=No
 2	晒	晒	PART	_	_	1	compound:quant	_	SpaceAfter=No
@@ -790,6 +871,7 @@
 5	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 82
+# parallel_id = hk/82
 # text = 爺爺，你再畀多我兩蚊吖！
 1	爺爺	爺爺	NOUN	_	_	5	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -804,6 +886,7 @@
 11	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 83
+# parallel_id = hk/83
 # text = 就嚟有閃卡㗎喇！
 1	就嚟	就唻	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	有	有	VERB	_	_	0	root	_	SpaceAfter=No
@@ -813,6 +896,7 @@
 6	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 84
+# parallel_id = hk/84
 # text = 爺爺，你畀我啦！
 1	爺爺	爺爺	NOUN	_	_	4	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -823,6 +907,7 @@
 7	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 85
+# parallel_id = hk/85
 # text = 你畀我啦！你畀我啦！你畀我啦！
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	畀	畀	VERB	_	_	0	root	_	SpaceAfter=No
@@ -841,11 +926,13 @@
 15	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 86
+# parallel_id = hk/86
 # text = 哎吔！
 1	哎吔	哎吔	INTJ	_	_	0	root	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 87
+# parallel_id = hk/87
 # text = 你畀我兩張啦！
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	畀	畀	VERB	_	_	0	root	_	SpaceAfter=No
@@ -856,11 +943,13 @@
 7	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 88
+# parallel_id = hk/88
 # text = 嘩！
 1	嘩	嘩	INTJ	_	_	0	root	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 89
+# parallel_id = hk/89
 # text = 係閃卡！好嘢！好嘢！
 1	係	係	AUX	_	_	2	cop	_	SpaceAfter=No
 2	閃卡	閃卡	NOUN	_	_	0	root	_	SpaceAfter=No
@@ -871,6 +960,7 @@
 7	！	！	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 90
+# parallel_id = hk/90
 # text = 快啲交換啦，交換啦！
 1	快	快	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	啲	啲	ADV	_	_	1	advmod	_	SpaceAfter=No
@@ -882,6 +972,7 @@
 8	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 91
+# parallel_id = hk/91
 # text = 攞嚟啦！
 1	攞	攞	VERB	_	_	0	root	_	SpaceAfter=No
 2	嚟	唻	VERB	_	_	1	compound:dir	_	SpaceAfter=No
@@ -889,6 +980,7 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 92
+# parallel_id = hk/92
 # text = 最衰都係爺爺啦。
 1	最	最	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	衰	衰	ADJ	_	_	5	csubj	_	SpaceAfter=No
@@ -899,6 +991,7 @@
 7	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 93
+# parallel_id = hk/93
 # text = 張閃卡本來係我㗎嘛。
 1	張	張	NOUN	_	NounType=Clf	2	clf:det	_	SpaceAfter=No
 2	閃卡	閃卡	NOUN	_	_	5	nsubj	_	SpaceAfter=No
@@ -909,12 +1002,14 @@
 7	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 94
+# parallel_id = hk/94
 # text = 走啦！
 1	走	走	VERB	_	_	0	root	_	SpaceAfter=No
 2	啦	喇	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 95
+# parallel_id = hk/95
 # text = 爺爺，我唔睬你呀！
 1	爺爺	爺爺	NOUN	_	_	5	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -926,6 +1021,7 @@
 8	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 96
+# parallel_id = hk/96
 # text = 真係一張閃都冇嘅喎。
 1	真係	真係	ADV	_	_	6	advmod	_	SpaceAfter=No
 2	一	一	NUM	_	_	4	nummod	_	SpaceAfter=No
@@ -938,6 +1034,7 @@
 9	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 97
+# parallel_id = hk/97
 # text = 咁多年㗎喇。
 1	咁	咁	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	多	多	DET	_	_	3	det	_	SpaceAfter=No
@@ -947,6 +1044,7 @@
 6	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 98
+# parallel_id = hk/98
 # text = 啲卡都冇咗啦。
 1	啲	啲	NOUN	_	NounType=Clf	2	clf:det	_	SpaceAfter=No
 2	卡	卡	NOUN	_	_	4	nsubj	_	SpaceAfter=No
@@ -957,6 +1055,7 @@
 7	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 99
+# parallel_id = hk/99
 # text = 欸，影張相畀阿哥睇先！
 1	欸	欸	INTJ	_	_	3	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	3	punct	_	SpaceAfter=No
@@ -970,6 +1069,7 @@
 10	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 100
+# parallel_id = hk/100
 # text = 你不如一陣先問下⋯⋯問下豪仔夜晚返唔返嚟食飯。
 1	你	你	PRON	_	_	8	nsubj	_	SpaceAfter=No
 2	不如	不如	ADV	_	_	8	advmod	_	SpaceAfter=No
@@ -989,17 +1089,20 @@
 16	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 101
+# parallel_id = hk/101
 # text = 有餸。
 1	有	有	VERB	_	_	0	root	_	SpaceAfter=No
 2	餸	餸	NOUN	_	_	1	obj	_	SpaceAfter=No
 3	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 102
+# parallel_id = hk/102
 # text = 哦。
 1	哦	哦	INTJ	_	_	0	root	_	SpaceAfter=No
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 103
+# parallel_id = hk/103
 # text = 哎，啲帶好麻煩。
 1	哎	哎	INTJ	_	_	6	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -1010,6 +1113,7 @@
 7	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 104
+# parallel_id = hk/104
 # text = 用下用下壞㗎啦。
 1	用	用	VERB	_	_	5	advcl	_	SpaceAfter=No
 2	下	下	ADV	_	_	1	advmod	_	SpaceAfter=No
@@ -1021,6 +1125,7 @@
 8	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 105
+# parallel_id = hk/105
 # text = 最衰都係嗰個無綫啦！
 1	最	最	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	衰	衰	ADJ	_	_	7	csubj	_	SpaceAfter=No
@@ -1033,6 +1138,7 @@
 9	！	！	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 106
+# parallel_id = hk/106
 # text = 咁夜先至播嗰啲卡通片，令到嗰啲細路呢，就晚晚喺度捱夜。
 1	咁	咁	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	夜	夜	ADJ	_	_	4	advcl	_	SpaceAfter=No
@@ -1053,11 +1159,13 @@
 17	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 107
+# parallel_id = hk/107
 # text = 唉！
 1	唉	唉	INTJ	_	_	0	root	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 108
+# parallel_id = hk/108
 # text = 都係過咗十二點幾先瞓。
 1	都	都	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	係	係	VERB	_	_	0	root	_	SpaceAfter=No
@@ -1071,6 +1179,7 @@
 10	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 109
+# parallel_id = hk/109
 # text = 我呢，同阿哥細細個嗰陣時，夜媽媽呢，都會特登走出廳嗰度呢，睇金田一㗎！
 1	我	我	PRON	_	_	15	nsubj	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -1098,6 +1207,7 @@
 24	！	！	PUNCT	_	_	21	punct	_	SpaceAfter=No
 
 # sent_id = 110
+# parallel_id = hk/110
 # text = 但係呢，冇開燈呢，真係好驚！
 1	但係	但係	CCONJ	_	_	11	advmod	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -1113,6 +1223,7 @@
 12	！	！	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 111
+# parallel_id = hk/111
 # text = 不過又驚畀你哋知道喎。
 1	不過	不過	CCONJ	_	_	3	advmod	_	SpaceAfter=No
 2	又	又	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -1124,6 +1235,7 @@
 8	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 112
+# parallel_id = hk/112
 # text = 你哋一個二個都係噉。
 1	你哋	你哋	PRON	_	_	5	nsubj	_	SpaceAfter=No
 2	一個二個	一個二個	PRON	_	_	1	compound	_	SpaceAfter=No
@@ -1133,6 +1245,7 @@
 6	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 113
+# parallel_id = hk/113
 # text = 爺爺，你再畀多我睇多兩個字啦！
 1	爺爺	爺爺	NOUN	_	_	5	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -1150,6 +1263,7 @@
 14	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 114
+# parallel_id = hk/114
 # text = 就嚟睇完㗎喇！
 1	就嚟	就唻	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	睇	睇	VERB	_	_	0	root	_	SpaceAfter=No
@@ -1159,18 +1273,21 @@
 6	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 115
+# parallel_id = hk/115
 # text = 走啦！
 1	走	走	VERB	_	_	0	root	_	SpaceAfter=No
 2	啦	喇	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 116
+# parallel_id = hk/116
 # text = 去瞓覺！
 1	去	去	VERB	_	_	0	root	_	SpaceAfter=No
 2	瞓覺	瞓覺	VERB	_	_	1	conj	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 117
+# parallel_id = hk/117
 # text = 聽日畀你睇返啲錄影帶！
 1	聽日	聽日	NOUN	_	_	4	obl:tmod	_	SpaceAfter=No
 2	畀	畀	VERB	_	_	4	advcl:coverb	_	SpaceAfter=No
@@ -1182,6 +1299,7 @@
 8	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 118
+# parallel_id = hk/118
 # text = 爺爺，你畀我睇啦！
 1	爺爺	爺爺	NOUN	_	_	4	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -1193,6 +1311,7 @@
 8	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 119
+# parallel_id = hk/119
 # text = 唔得，唔得！
 1	唔	唔	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	得	得	VERB	_	_	0	root	_	SpaceAfter=No
@@ -1202,6 +1321,7 @@
 6	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 120
+# parallel_id = hk/120
 # text = 走啦，走啦，走！
 1	走	走	VERB	_	_	0	root	_	SpaceAfter=No
 2	啦	喇	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -1213,6 +1333,7 @@
 8	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 121
+# parallel_id = hk/121
 # text = 爺爺，你畀我睇埋啦！你畀我睇埋啦！
 1	爺爺	爺爺	NOUN	_	_	4	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -1232,12 +1353,14 @@
 16	！	！	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 122
+# parallel_id = hk/122
 # text = 瞓覺嘞！
 1	瞓覺	瞓覺	VERB	_	_	0	root	_	SpaceAfter=No
 2	嘞	嘞	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 123
+# parallel_id = hk/123
 # text = 你畀我睇埋啦！
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	畀	畀	VERB	_	_	0	root	_	SpaceAfter=No
@@ -1248,24 +1371,28 @@
 7	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 124
+# parallel_id = hk/124
 # text = 走啦！
 1	走	走	VERB	_	_	0	root	_	SpaceAfter=No
 2	啦	喇	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 125
+# parallel_id = hk/125
 # text = 走啦！
 1	走	走	VERB	_	_	0	root	_	SpaceAfter=No
 2	啦	喇	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 126
+# parallel_id = hk/126
 # text = 快啲！
 1	快	快	ADJ	_	_	0	root	_	SpaceAfter=No
 2	啲	啲	ADV	_	_	1	advmod	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 127
+# parallel_id = hk/127
 # text = 快啲瞓！
 1	快	快	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	啲	啲	ADV	_	_	1	advmod	_	SpaceAfter=No
@@ -1273,6 +1400,7 @@
 4	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 128
+# parallel_id = hk/128
 # text = 你哋成日都唔幫我錄㗎啦。
 1	你哋	你哋	PRON	_	_	7	nsubj	_	SpaceAfter=No
 2	成日	成日	ADV	_	_	7	advmod	_	SpaceAfter=No
@@ -1286,6 +1414,7 @@
 10	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 129
+# parallel_id = hk/129
 # text = 嗰日之後呢，我哋開始識得玩㗎喇。
 1	嗰	嗰	DET	_	_	2	det	_	SpaceAfter=No
 2	日	日	NOUN	_	NounType=Clf	7	obl:tmod	_	SpaceAfter=No
@@ -1301,6 +1430,7 @@
 12	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 130
+# parallel_id = hk/130
 # text = 通常呢，有二十幾張白卡呢，就有一張閃卡嚟㗎。
 1	通常	通常	NOUN	_	_	11	obl:tmod	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -1321,6 +1451,7 @@
 17	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 131
+# parallel_id = hk/131
 # text = 我哋開始識得排隊。
 1	我哋	我哋	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	開始	開始	VERB	_	_	0	root	_	SpaceAfter=No
@@ -1329,6 +1460,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 132
+# parallel_id = hk/132
 # text = 見倒人哋有十個一蚊左右呢，就企喺佢後面。
 1	見	見	VERB	_	_	13	advcl	_	SpaceAfter=No
 2	倒	倒	VERB	_	_	1	compound:vv	_	SpaceAfter=No
@@ -1349,6 +1481,7 @@
 17	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No
 
 # sent_id = 133
+# parallel_id = hk/133
 # text = 等佢哋用完呢，又唔中呢，就等我哋抽。
 1	等	等	VERB	_	_	13	advcl	_	SpaceAfter=No
 2	佢哋	佢哋	PRON	_	_	1	obj	_	SpaceAfter=No
@@ -1368,6 +1501,7 @@
 16	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No
 
 # sent_id = 134
+# parallel_id = hk/134
 # text = 扭卡就一定要帶電筒。
 1	扭	扭	VERB	_	_	6	advcl	_	SpaceAfter=No
 2	卡	卡	NOUN	_	_	1	obj	_	SpaceAfter=No
@@ -1379,6 +1513,7 @@
 8	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 135
+# parallel_id = hk/135
 # text = 唏！做賊咁做。
 1	唏	唏	INTJ	_	_	6	discourse	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -1389,6 +1524,7 @@
 7	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 136
+# parallel_id = hk/136
 # text = 喂，𡃁仔！
 1	喂	喂	INTJ	_	_	3	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -1396,6 +1532,7 @@
 4	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 137
+# parallel_id = hk/137
 # text = 做乜整壞我部機呀？
 1	做乜	做乜	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	整	整	VERB	_	_	0	root	_	SpaceAfter=No
@@ -1407,12 +1544,14 @@
 8	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 138
+# parallel_id = hk/138
 # text = 對唔住呀！
 1	對唔住	對唔住	VERB	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 139
+# parallel_id = hk/139
 # text = 呀，仲走喎！
 1	呀	呀	PART	_	_	4	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -1422,12 +1561,14 @@
 6	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 140
+# parallel_id = hk/140
 # text = 快啲！
 1	快	快	ADJ	_	_	0	root	_	SpaceAfter=No
 2	啲	啲	ADV	_	_	1	advmod	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 141
+# parallel_id = hk/141
 # text = 走唔倒喇！
 1	走	走	VERB	_	_	0	root	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -1436,6 +1577,7 @@
 5	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 142
+# parallel_id = hk/142
 # text = 爺爺，快啲啦！
 1	爺爺	爺爺	NOUN	_	_	3	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -1445,6 +1587,7 @@
 6	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 143
+# parallel_id = hk/143
 # text = 就嚟畀人捉㗎喇！
 1	就嚟	就唻	ADV	_	_	4	advmod	_	SpaceAfter=No
 2	畀	畀	ADP	_	_	3	case	_	SpaceAfter=No
@@ -1455,11 +1598,13 @@
 7	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 144
+# parallel_id = hk/144
 # text = 豪仔！
 1	豪仔	豪仔	PROPN	_	_	0	root	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 145
+# parallel_id = hk/145
 # text = 豪仔，你喺邊呀？
 1	豪仔	豪仔	PROPN	_	_	4	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -1470,11 +1615,13 @@
 7	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 146
+# parallel_id = hk/146
 # text = 豪仔！
 1	豪仔	豪仔	PROPN	_	_	0	root	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 147
+# parallel_id = hk/147
 # text = 喺邊呀，你？
 1	喺	喺	VERB	_	_	0	root	_	SpaceAfter=No
 2	邊	邊	PRON	_	_	1	obj	_	SpaceAfter=No
@@ -1484,12 +1631,14 @@
 6	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 148
+# parallel_id = hk/148
 # text = 好攰。
 1	好	好	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	攰	攰	ADJ	_	_	0	root	_	SpaceAfter=No
 3	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 149
+# parallel_id = hk/149
 # text = 爺爺呀，你睇下！
 1	爺爺	爺爺	NOUN	_	_	5	vocative	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -1500,6 +1649,7 @@
 7	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 150
+# parallel_id = hk/150
 # text = 喂呀，啲閃喺佢度呀，原來。
 1	喂	喂	INTJ	_	_	6	discourse	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -1515,6 +1665,7 @@
 12	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 151
+# parallel_id = hk/151
 # text = 唏，你點知㗎？
 1	唏	唏	INTJ	_	_	5	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -1525,6 +1676,7 @@
 7	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 152
+# parallel_id = hk/152
 # text = 佢啱啱話畀我聽嘅。
 1	佢	佢	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	啱啱	啱啱	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -1536,12 +1688,14 @@
 8	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 153
+# parallel_id = hk/153
 # text = 係咩？
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	咩	咩	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 154
+# parallel_id = hk/154
 # text = 喂，你成日同阿哥細個嗰陣時周圍去。
 1	喂	喂	INTJ	_	_	10	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -1556,6 +1710,7 @@
 11	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 155
+# parallel_id = hk/155
 # text = 噉我去咗邊呀？
 1	噉	噉	ADV	_	_	3	discourse	_	SpaceAfter=No
 2	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -1566,12 +1721,14 @@
 7	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 156
+# parallel_id = hk/156
 # text = 你呀？
 1	你	你	PRON	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 157
+# parallel_id = hk/157
 # text = 你都未出世！
 1	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No
 2	都	都	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -1580,6 +1737,7 @@
 5	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 158
+# parallel_id = hk/158
 # text = 未出世？點會呀？
 1	未	未	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	出世	出世	VERB	_	_	0	root	_	SpaceAfter=No
@@ -1590,6 +1748,7 @@
 7	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 159
+# parallel_id = hk/159
 # text = 我先啱啱細阿哥幾年。
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No
 2	先	先	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -1601,6 +1760,7 @@
 8	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 160
+# parallel_id = hk/160
 # text = 唏！唔記得囉喎！
 1	唏	唏	INTJ	_	_	3	discourse	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -1610,12 +1770,14 @@
 6	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 161
+# parallel_id = hk/161
 # text = 你偏心！
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	偏心	偏心	VERB	_	_	0	root	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 162
+# parallel_id = hk/162
 # text = 哎！等等等等我嚟！
 1	哎	哎	INTJ	_	_	3	discourse	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -1628,6 +1790,7 @@
 9	！	！	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 163
+# parallel_id = hk/163
 # text = 你坐低，你坐低！
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	坐	坐	VERB	_	_	0	root	_	SpaceAfter=No
@@ -1639,6 +1802,7 @@
 8	！	！	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 164
+# parallel_id = hk/164
 # text = 哎吔，你心虛呀？
 1	哎吔	哎吔	INTJ	_	_	4	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -1648,6 +1812,7 @@
 6	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 165
+# parallel_id = hk/165
 # text = 你快啲執嘢啦！
 1	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No
 2	快	快	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -1657,6 +1822,7 @@
 6	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 166
+# parallel_id = hk/166
 # text = 又話拎啲嘢畀你阿哥！
 1	又	又	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	話	話	VERB	_	_	0	root	_	SpaceAfter=No
@@ -1669,6 +1835,7 @@
 9	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 167
+# parallel_id = hk/167
 # text = 佢女朋友喺度。
 1	佢	佢	PRON	_	_	2	nmod	_	SpaceAfter=No
 2	女朋友	女朋友	NOUN	_	_	3	nsubj	_	SpaceAfter=No
@@ -1676,6 +1843,7 @@
 4	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 168
+# parallel_id = hk/168
 # text = 我過到去呀，驚做電燈膽呀。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	過到去	過到去	VERB	_	_	0	root	_	SpaceAfter=No
@@ -1688,6 +1856,7 @@
 9	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 169
+# parallel_id = hk/169
 # text = 哎，知唔知呀？
 1	哎	哎	INTJ	_	_	3	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	3	punct	_	SpaceAfter=No
@@ -1698,6 +1867,7 @@
 7	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 170
+# parallel_id = hk/170
 # text = 嗰陣時呢，陳奕迅同埋楊千嬅呢，啱啱出道嗰陣時，佢哋兩個係一齊㗎。
 1	嗰陣時	嗰陣時	NOUN	_	_	17	obl:tmod	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -1720,6 +1890,7 @@
 19	。	。	PUNCT	_	_	17	punct	_	SpaceAfter=No
 
 # sent_id = 171
+# parallel_id = hk/171
 # text = 愾！我又唔識佢哋。
 1	愾	愾	INTJ	_	_	6	discourse	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -1731,6 +1902,7 @@
 8	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 172
+# parallel_id = hk/172
 # text = 係啦，你哋一個⋯⋯好似中意⋯⋯嗰個咩……哦，Eason，一個呢，就中意嗰個⋯⋯黎明。
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	啦	喇	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -1763,6 +1935,7 @@
 29	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 173
+# parallel_id = hk/173
 # text = 愾！你哋啲嘢邊個打邊個，唔知㗎嘞。
 1	愾	愾	INTJ	_	_	7	discourse	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -1780,6 +1953,7 @@
 14	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 174
+# parallel_id = hk/174
 # text = 邊個中意黎明呀？
 1	邊個	邊個	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	中意	中意	VERB	_	_	0	root	_	SpaceAfter=No
@@ -1788,6 +1962,7 @@
 5	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 175
+# parallel_id = hk/175
 # text = 肯定係阿哥屈我啦！
 1	肯定	肯定	VERB	_	_	0	root	_	SpaceAfter=No
 2	係	係	VERB	_	_	1	ccomp	_	SpaceAfter=No
@@ -1798,6 +1973,7 @@
 7	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 176
+# parallel_id = hk/176
 # text = 我都冇中意明星嘅！
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No
 2	都	都	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -1808,6 +1984,7 @@
 7	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 177
+# parallel_id = hk/177
 # text = 你可以⋯⋯做我的⋯⋯筆友嗎？
 1	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No
 2	可以	可以	AUX	_	_	4	aux	_	SpaceAfter=No
@@ -1821,6 +1998,7 @@
 10	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 178
+# parallel_id = hk/178
 # text = 我都冇上堂，你知㗎啦！
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No
 2	都	都	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -1834,6 +2012,7 @@
 10	！	！	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 179
+# parallel_id = hk/179
 # text = 咩mode、mean、median？
 1	咩	咩	PRON	_	_	2	det	_	SpaceAfter=No
 2	mode	mode	NOUN	_	_	0	root	_	SpaceAfter=No
@@ -1844,6 +2023,7 @@
 7	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 180
+# parallel_id = hk/180
 # text = 點分呀？
 1	點	點	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	分	分	VERB	_	_	0	root	_	SpaceAfter=No
@@ -1851,6 +2031,7 @@
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 181
+# parallel_id = hk/181
 # text = 我唔識喎。
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -1859,6 +2040,7 @@
 5	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 182
+# parallel_id = hk/182
 # text = 最高頻率嗰組呀？
 1	最	最	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	高	高	ADJ	_	_	3	amod	_	SpaceAfter=No
@@ -1869,17 +2051,20 @@
 7	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 183
+# parallel_id = hk/183
 # text = 哦。
 1	哦	哦	INTJ	_	_	0	root	_	SpaceAfter=No
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 184
+# parallel_id = hk/184
 # text = Mean呢？
 1	Mean	Mean	NOUN	_	_	0	root	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 185
+# parallel_id = hk/185
 # text = 你就mean！
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	就	就	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -1887,6 +2072,7 @@
 4	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 186
+# parallel_id = hk/186
 # text = 就搵返嗰橛出嚟，哦，就係噉！
 1	就	就	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	搵	搵	VERB	_	_	0	root	_	SpaceAfter=No
@@ -1903,12 +2089,14 @@
 13	！	！	PUNCT	_	_	12	punct	_	SpaceAfter=No
 
 # sent_id = 187
+# parallel_id = hk/187
 # text = 差唔多啦。
 1	差唔多	差唔多	VERB	_	_	0	root	_	SpaceAfter=No
 2	啦	喇	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 188
+# parallel_id = hk/188
 # text = 第七條我做咗嘞，histogram。
 1	第七	第七	ADJ	_	_	2	amod	_	SpaceAfter=No
 2	條	條	NOUN	_	NounType=Clf	4	obj:periph	_	SpaceAfter=No
@@ -1921,6 +2109,7 @@
 9	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 189
+# parallel_id = hk/189
 # text = 黐埋一齊嗰個叫histogram吖嘛。
 1	黐	黐	VERB	_	_	4	acl	_	SpaceAfter=No
 2	埋	埋	VERB	_	_	1	compound:vv	_	SpaceAfter=No
@@ -1932,6 +2121,7 @@
 8	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 190
+# parallel_id = hk/190
 # text = 我知呀，呢個。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	知	知	VERB	_	_	0	root	_	SpaceAfter=No
@@ -1941,6 +2131,7 @@
 6	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 191
+# parallel_id = hk/191
 # text = 呀，Eason嗰隻碟呢，你有冇聽呀？
 1	呀	呀	PART	_	_	12	discourse:sp	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -1958,6 +2149,7 @@
 14	？	？	PUNCT	_	_	12	punct	_	SpaceAfter=No
 
 # sent_id = 192
+# parallel_id = hk/192
 # text = 梗係有千嬅份啦！
 1	梗係	梗係	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	有	有	VERB	_	_	0	root	_	SpaceAfter=No
@@ -1967,6 +2159,7 @@
 6	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 193
+# parallel_id = hk/193
 # text = 佢哋咁friend。
 1	佢哋	佢哋	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	咁	咁	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -1974,6 +2167,7 @@
 4	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 194
+# parallel_id = hk/194
 # text = 你未聽呀？
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	未	未	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -1982,6 +2176,7 @@
 5	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 195
+# parallel_id = hk/195
 # text = 你等我一陣。
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	等	等	VERB	_	_	0	root	_	SpaceAfter=No
@@ -1990,6 +2185,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 196
+# parallel_id = hk/196
 # text = 我播畀你聽，你等我一陣。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	播	播	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2004,17 +2200,20 @@
 11	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 197
+# parallel_id = hk/197
 # text = 黎明？
 1	黎明	黎明	PROPN	_	_	0	root	_	SpaceAfter=No
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 198
+# parallel_id = hk/198
 # text = Badtaste！
 1	Bad	Bad	ADJ	_	_	2	amod	_	SpaceAfter=No
 2	taste	taste	NOUN	_	_	0	root	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 199
+# parallel_id = hk/199
 # text = 關你咩事呀？
 1	關	關	VERB	_	_	0	root	_	SpaceAfter=No
 2	你	你	PRON	_	_	4	nmod	_	SpaceAfter=No
@@ -2024,6 +2223,7 @@
 6	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 200
+# parallel_id = hk/200
 # text = 喂，你做咩呀？
 1	喂	喂	INTJ	_	_	4	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -2034,6 +2234,7 @@
 7	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 201
+# parallel_id = hk/201
 # text = 人哋聽緊㗎！
 1	人哋	人哋	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	聽	聽	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2042,6 +2243,7 @@
 5	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 202
+# parallel_id = hk/202
 # text = 開咩電視唧？
 1	開	開	VERB	_	_	0	root	_	SpaceAfter=No
 2	咩	咩	DET	_	_	3	det	_	SpaceAfter=No
@@ -2050,6 +2252,7 @@
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 203
+# parallel_id = hk/203
 # text = 米阻住晒啦！
 1	米	米	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	阻住	阻住	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2058,12 +2261,14 @@
 5	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 204
+# parallel_id = hk/204
 # text = 唔好嘈！
 1	唔好	唔好	AUX	_	_	2	aux	_	SpaceAfter=No
 2	嘈	嘈	VERB	_	_	0	root	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 205
+# parallel_id = hk/205
 # text = 噉我係要聽吖嘛！
 1	噉	噉	ADV	_	_	3	discourse	_	SpaceAfter=No
 2	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -2074,12 +2279,14 @@
 7	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 206
+# parallel_id = hk/206
 # text = 得喇！
 1	得	得	VERB	_	_	0	root	_	SpaceAfter=No
 2	喇	嘑	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 207
+# parallel_id = hk/207
 # text = 噉你坐低就唔好講咁多嘢啦！
 1	噉	噉	ADV	_	_	7	discourse	_	SpaceAfter=No
 2	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -2095,6 +2302,7 @@
 12	！	！	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 208
+# parallel_id = hk/208
 # text = 好煩呀，你！
 1	好	好	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	煩	煩	ADJ	_	_	0	root	_	SpaceAfter=No
@@ -2104,6 +2312,7 @@
 6	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 209
+# parallel_id = hk/209
 # text = 你返去做你嘅功課啦！
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	返去	返去	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2115,6 +2324,7 @@
 8	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 210
+# parallel_id = hk/210
 # text = 一路做功課就一路聽！
 1	一路	一路	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	做	做	VERB	_	_	6	advcl	_	SpaceAfter=No
@@ -2125,6 +2335,7 @@
 7	！	！	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 211
+# parallel_id = hk/211
 # text = 邊個打嚟呀？
 1	邊個	邊個	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	打	打	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2133,6 +2344,7 @@
 5	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 212
+# parallel_id = hk/212
 # text = 關你鬼事呀？殊！
 1	關	關	VERB	_	_	0	root	_	SpaceAfter=No
 2	你	你	PRON	_	_	4	nmod	_	SpaceAfter=No
@@ -2144,6 +2356,7 @@
 8	！	！	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 213
+# parallel_id = hk/213
 # text = 喂？喂？
 1	喂	喂	INTJ	_	_	0	root	_	SpaceAfter=No
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -2151,6 +2364,7 @@
 4	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 214
+# parallel_id = hk/214
 # text = 聽唔聽倒呀？
 1	聽	聽	VERB	_	_	0	root	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -2160,6 +2374,7 @@
 6	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 215
+# parallel_id = hk/215
 # text = 係呀，新出㗎，呢隻！
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -2173,6 +2388,7 @@
 10	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 216
+# parallel_id = hk/216
 # text = 未聽過褦！
 1	未	未	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	聽	聽	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2181,6 +2397,7 @@
 5	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 217
+# parallel_id = hk/217
 # text = 你覺得呢，Eason同千嬅有冇機會一齊吖嗱？
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	覺得	覺得	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2197,6 +2414,7 @@
 13	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 218
+# parallel_id = hk/218
 # text = 都幾襯吖，佢哋。
 1	都	都	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	幾	幾	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -2207,6 +2425,7 @@
 7	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 219
+# parallel_id = hk/219
 # text = 而家Eason好失禮你咩？
 1	而家	而家	NOUN	_	_	4	obl:tmod	_	SpaceAfter=No
 2	Eason	Eason	PROPN	_	_	4	nsubj	_	SpaceAfter=No
@@ -2217,6 +2436,7 @@
 7	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 220
+# parallel_id = hk/220
 # text = 喺未有ＭＰ３嘅年代，電台播咩歌，我哋就興咩歌。
 1	喺	喺	ADP	_	_	15	case	_	SpaceAfter=No
 2	未	未	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -2238,6 +2458,7 @@
 18	。	。	PUNCT	_	_	15	punct	_	SpaceAfter=No
 
 # sent_id = 221
+# parallel_id = hk/221
 # text = 喺九零三同埋新城之間轉嚟轉去。
 1	喺	喺	ADP	_	_	2	case	_	SpaceAfter=No
 2	九零三	九零三	PROPN	_	_	6	obl	_	SpaceAfter=No
@@ -2251,6 +2472,7 @@
 10	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 222
+# parallel_id = hk/222
 # text = 阿哥佢中意聽陳奕迅嘅話，我就聽陳奕迅。
 1	阿哥	阿哥	NOUN	_	_	4	nsubj	_	SpaceAfter=No
 2	佢	佢	PRON	_	_	1	appos	_	SpaceAfter=No
@@ -2266,6 +2488,7 @@
 12	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 223
+# parallel_id = hk/223
 # text = 你要聽歌可以用十蚊去買一隻雜錦錄音帶，又或者係用廿蚊去買一隻老翻。
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	要	要	AUX	_	_	3	aux	_	SpaceAfter=No
@@ -2296,6 +2519,7 @@
 27	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 224
+# parallel_id = hk/224
 # text = 但係你叫得你自己做fen1si2嘅話，梗係買華星正版啦！
 1	但係	但係	CCONJ	_	_	3	advmod	_	SpaceAfter=No
 2	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -2314,6 +2538,7 @@
 15	！	！	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 225
+# parallel_id = hk/225
 # text = 嗰陣時啲CD舖仲多過而家啲七十一。
 1	嗰陣時	嗰陣時	NOUN	_	_	4	nmod	_	SpaceAfter=No
 2	啲	啲	NOUN	_	NounType=Clf	4	clf:det	_	SpaceAfter=No
@@ -2328,6 +2553,7 @@
 11	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 226
+# parallel_id = hk/226
 # text = 明明啲CD同而家一樣都係一百蚊倒咋嘛。
 1	明明	明明	ADV	_	_	6	advmod	_	SpaceAfter=No
 2	啲	啲	NOUN	_	NounType=Clf	3	clf:det	_	SpaceAfter=No
@@ -2344,6 +2570,7 @@
 13	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 227
+# parallel_id = hk/227
 # text = Eason每兩至三個月就出一次新碟。
 1	Eason	Eason	PROPN	_	_	9	nsubj	_	SpaceAfter=No
 2	每	每	DET	_	_	7	det	_	SpaceAfter=No
@@ -2361,6 +2588,7 @@
 14	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 228
+# parallel_id = hk/228
 # text = 但係細個嗰陣時就反而多多都買得起。
 1	但係	但係	CCONJ	_	_	8	advmod	_	SpaceAfter=No
 2	細個	細個	ADJ	_	_	3	amod	_	SpaceAfter=No
@@ -2375,6 +2603,7 @@
 11	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 229
+# parallel_id = hk/229
 # text = 唔知阿哥乜嘢叫做好tei1si2啦。
 1	唔	唔	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	知	知	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2387,6 +2616,7 @@
 9	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 230
+# parallel_id = hk/230
 # text = 總之就日日係噉喺度聽囖。
 1	總之	總之	ADV	_	_	6	advmod	_	SpaceAfter=No
 2	就	就	ADV	_	_	6	advmod	_	SpaceAfter=No
@@ -2398,6 +2628,7 @@
 8	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 231
+# parallel_id = hk/231
 # text = 又係得腸粉！
 1	又	又	ADV	_	_	4	advmod	_	SpaceAfter=No
 2	係	係	AUX	_	_	4	cop	_	SpaceAfter=No
@@ -2406,6 +2637,7 @@
 5	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 232
+# parallel_id = hk/232
 # text = 我要食蛋撻呀！
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	要	要	AUX	_	_	3	aux	_	SpaceAfter=No
@@ -2415,6 +2647,7 @@
 6	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 233
+# parallel_id = hk/233
 # text = 你快啲食啦！
 1	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No
 2	快	快	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -2424,6 +2657,7 @@
 6	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 234
+# parallel_id = hk/234
 # text = 如果唔係呀，阿爺大家樂見唔倒我哋呢，就死㗎喇。
 1	如果	如果	SCONJ	_	_	3	mark	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -2445,6 +2679,7 @@
 18	。	。	PUNCT	_	_	15	punct	_	SpaceAfter=No
 
 # sent_id = 235
+# parallel_id = hk/235
 # text = 啲CD又唔係我嘅！
 1	啲	啲	NOUN	_	NounType=Clf	2	clf:det	_	SpaceAfter=No
 2	CD	CD	NOUN	_	_	6	nsubj	_	SpaceAfter=No
@@ -2456,6 +2691,7 @@
 8	！	！	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 236
+# parallel_id = hk/236
 # text = 快啲畀返啲錢我呀！
 1	快	快	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	啲	啲	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -2468,6 +2704,7 @@
 9	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 237
+# parallel_id = hk/237
 # text = 你冇份聽嘅，冇份唱嘅，係咪呀？
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	冇份	冇份	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2483,6 +2720,7 @@
 12	？	？	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 238
+# parallel_id = hk/238
 # text = 兩包腸粉就六蚊，十二蚊⋯⋯
 1	兩	兩	NUM	_	_	3	nummod	_	SpaceAfter=No
 2	包	包	NOUN	_	NounType=Clf	1	clf	_	SpaceAfter=No
@@ -2496,6 +2734,7 @@
 10	⋯⋯	⋯⋯	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 239
+# parallel_id = hk/239
 # text = 怕咗你喇！
 1	怕	怕	VERB	_	_	0	root	_	SpaceAfter=No
 2	咗	咗	AUX	_	_	1	aux	_	SpaceAfter=No
@@ -2504,6 +2743,7 @@
 5	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 240
+# parallel_id = hk/240
 # text = 畀返兩蚊你囖，好唔好呀？
 1	畀	畀	VERB	_	_	0	root	_	SpaceAfter=No
 2	返	返	VERB	_	_	1	compound:dir	_	SpaceAfter=No
@@ -2517,6 +2757,7 @@
 10	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 241
+# parallel_id = hk/241
 # text = 唔得呀！
 1	唔	唔	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	得	得	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2524,6 +2765,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 242
+# parallel_id = hk/242
 # text = 唔公平呀！
 1	唔	唔	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	公平	公平	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2531,12 +2773,14 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 243
+# parallel_id = hk/243
 # text = 十蚊！
 1	十	十	NUM	_	_	2	nummod	_	SpaceAfter=No
 2	蚊	緡	NOUN	_	NounType=Clf	0	root	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 244
+# parallel_id = hk/244
 # text = 五蚊啦！
 1	五	五	NUM	_	_	2	nummod	_	SpaceAfter=No
 2	蚊	緡	NOUN	_	NounType=Clf	0	root	_	SpaceAfter=No
@@ -2544,6 +2788,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 245
+# parallel_id = hk/245
 # text = 唔得呀！
 1	唔	唔	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	得	得	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2551,6 +2796,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 246
+# parallel_id = hk/246
 # text = 除非⋯⋯你買本Yes!畀我。
 1	除非	除非	ADV	_	_	4	advmod	_	SpaceAfter=No
 2	⋯⋯	⋯⋯	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -2563,6 +2809,7 @@
 9	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 247
+# parallel_id = hk/247
 # text = 你痴線嘅！
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	痴線	痴線	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2570,12 +2817,14 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 248
+# parallel_id = hk/248
 # text = 咁貴！
 1	咁	咁	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	貴	貴	ADJ	_	_	0	root	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 249
+# parallel_id = hk/249
 # text = 你問同學借嚟睇咪算囖。
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	問	問	VERB	_	_	8	advcl	_	SpaceAfter=No
@@ -2589,6 +2838,7 @@
 10	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 250
+# parallel_id = hk/250
 # text = 唔得呀！
 1	唔	唔	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	得	得	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2596,6 +2846,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 251
+# parallel_id = hk/251
 # text = 我話畀媽咪知！
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	話	話	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2605,6 +2856,7 @@
 6	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 252
+# parallel_id = hk/252
 # text = 抑係噉嘞，我畀兩蚊你，再加多三張Yes!卡。
 1	抑係	抑係	CCONJ	_	_	2	cc	_	SpaceAfter=No
 2	噉	噉	ADV	_	_	0	root	_	SpaceAfter=No
@@ -2626,6 +2878,7 @@
 18	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 253
+# parallel_id = hk/253
 # text = 好未呀？
 1	好	好	ADJ	_	_	0	root	_	SpaceAfter=No
 2	未	未	ADV	_	_	1	advmod	_	SpaceAfter=No
@@ -2633,12 +2886,14 @@
 4	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 254
+# parallel_id = hk/254
 # text = 好啦！
 1	好	好	ADJ	_	_	0	root	_	SpaceAfter=No
 2	啦	喇	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 255
+# parallel_id = hk/255
 # text = 嗱，一陣就去呀！
 1	嗱	嗱	INTJ	_	_	5	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -2649,6 +2904,7 @@
 7	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 256
+# parallel_id = hk/256
 # text = 誒，食啦！
 1	誒	誒	INTJ	_	_	3	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -2657,6 +2913,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 257
+# parallel_id = hk/257
 # text = 嗰日，阿哥買返嚟嘅竟然唔係陳奕迅，而係楊千嬅嘅碟。
 1	嗰	嗰	DET	_	_	2	det	_	SpaceAfter=No
 2	日	日	NOUN	_	NounType=Clf	5	obl:tmod	_	SpaceAfter=No
@@ -2678,6 +2935,7 @@
 18	。	。	PUNCT	_	_	17	punct	_	SpaceAfter=No
 
 # sent_id = 258
+# parallel_id = hk/258
 # text = 屋企仲出現咗本Yes!。
 1	屋企	屋企	NOUN	_	_	3	obl	_	SpaceAfter=No
 2	仲	仲	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -2688,6 +2946,7 @@
 7	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 259
+# parallel_id = hk/259
 # text = 等我仲以為阿哥佢對我咁好。
 1	等	等	VERB	_	_	0	root	_	SpaceAfter=No
 2	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -2702,6 +2961,7 @@
 11	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 260
+# parallel_id = hk/260
 # text = 第二日我拎住本爛吓爛吓嘅Yes!，問佢封面去咗邊。
 1	第二	第二	ADJ	_	_	2	amod	_	SpaceAfter=No
 2	日	日	NOUN	_	NounType=Clf	4	obl:tmod	_	SpaceAfter=No
@@ -2722,6 +2982,7 @@
 17	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 261
+# parallel_id = hk/261
 # text = 嗰時我先知道佢嘅goodtaste唔係陳奕迅。
 1	嗰時	嗰時	PRON	_	_	4	obl:tmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -2737,6 +2998,7 @@
 12	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 262
+# parallel_id = hk/262
 # text = 應該都唔係楊千嬅。
 1	應該	應該	AUX	_	_	5	aux	_	SpaceAfter=No
 2	都	都	ADV	_	_	5	advmod	_	SpaceAfter=No
@@ -2746,6 +3008,7 @@
 6	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 263
+# parallel_id = hk/263
 # text = 愾！我都唔知你哋咩tei1唔tei1si2。
 1	愾	愾	INTJ	_	_	6	discourse	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -2759,6 +3022,7 @@
 10	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 264
+# parallel_id = hk/264
 # text = 反正呢啲歌呀，我都唔識聽。
 1	反正	反正	ADV	_	_	10	advmod	_	SpaceAfter=No
 2	呢啲	呢啲	DET	_	_	3	det	_	SpaceAfter=No
@@ -2773,6 +3037,7 @@
 11	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 265
+# parallel_id = hk/265
 # text = 有咩好聽唧？
 1	有	有	VERB	_	_	0	root	_	SpaceAfter=No
 2	咩	咩	PRON	_	_	1	obj	_	SpaceAfter=No
@@ -2782,6 +3047,7 @@
 6	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 266
+# parallel_id = hk/266
 # text = 唔知呢？
 1	唔	唔	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	知	知	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2789,11 +3055,13 @@
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 267
+# parallel_id = hk/267
 # text = 哦。
 1	哦	哦	INTJ	_	_	0	root	_	SpaceAfter=No
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 268
+# parallel_id = hk/268
 # text = 用angle-sum-of-triangle嘅咩？
 1	用	用	VERB	_	_	0	root	_	SpaceAfter=No
 2	angle-sum-of-triangle	angle-sum-of-triangle	PROPN	_	_	1	obj	_	SpaceAfter=No
@@ -2802,11 +3070,13 @@
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 269
+# parallel_id = hk/269
 # text = 哦。
 1	哦	哦	INTJ	_	_	0	root	_	SpaceAfter=No
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 270
+# parallel_id = hk/270
 # text = 你做晒嗱？
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	做	做	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2815,6 +3085,7 @@
 5	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 271
+# parallel_id = hk/271
 # text = 你就好啦！
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	就	就	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -2823,6 +3094,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 272
+# parallel_id = hk/272
 # text = 我有排都未做完呀。
 1	我	我	PRON	_	_	5	nsubj	_	SpaceAfter=No
 2	有排	有排	ADV	_	_	5	advmod	_	SpaceAfter=No
@@ -2834,6 +3106,7 @@
 8	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 273
+# parallel_id = hk/273
 # text = 係呀，你快啲教我啦，唔識做呀。
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -2852,6 +3125,7 @@
 15	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 274
+# parallel_id = hk/274
 # text = 你可唔可以唔好嘈呀？
 1	你	你	PRON	_	_	6	nsubj	_	SpaceAfter=No
 2	可	可以	AUX	_	_	6	aux	_	SpaceAfter=No
@@ -2863,6 +3137,7 @@
 8	？	？	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 275
+# parallel_id = hk/275
 # text = 我做緊英文功課呀！
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	做	做	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2873,6 +3148,7 @@
 7	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 276
+# parallel_id = hk/276
 # text = 你等我一陣呀，吓？
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	等	等	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2884,6 +3160,7 @@
 8	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 277
+# parallel_id = hk/277
 # text = 我夠問緊功課啦！
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	夠	夠	ADJ	_	_	3	advmod	_	SpaceAfter=No
@@ -2894,6 +3171,7 @@
 7	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 278
+# parallel_id = hk/278
 # text = 得你要做呀？
 1	得	得	ADV	_	_	4	advmod	_	SpaceAfter=No
 2	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -2903,6 +3181,7 @@
 6	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 279
+# parallel_id = hk/279
 # text = 大蝦細！
 1	大	大	ADJ	_	_	2	amod	_	SpaceAfter=No
 2	蝦	蝦	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2910,6 +3189,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 280
+# parallel_id = hk/280
 # text = 你做過第二份先啦！
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	做	做	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2921,6 +3201,7 @@
 8	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 281
+# parallel_id = hk/281
 # text = 唔得呀，得呢份咋！
 1	唔	唔	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	得	得	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2933,6 +3214,7 @@
 9	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 282
+# parallel_id = hk/282
 # text = 八號交喇！
 1	八號	八號	NOUN	_	_	2	obl:tmod	_	SpaceAfter=No
 2	交	交	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2940,6 +3222,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 283
+# parallel_id = hk/283
 # text = 你等一陣，吓？
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	等	等	VERB	_	_	0	root	_	SpaceAfter=No
@@ -2949,6 +3232,7 @@
 6	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 284
+# parallel_id = hk/284
 # text = 怕咗你呀！
 1	怕	怕	VERB	_	_	0	root	_	SpaceAfter=No
 2	咗	咗	AUX	_	_	1	aux	_	SpaceAfter=No
@@ -2957,6 +3241,7 @@
 5	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 285
+# parallel_id = hk/285
 # text = 等一陣啦，吓？
 1	等	等	VERB	_	_	0	root	_	SpaceAfter=No
 2	一陣	一陣	ADV	_	_	1	advmod:df	_	SpaceAfter=No
@@ -2966,11 +3251,13 @@
 6	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 286
+# parallel_id = hk/286
 # text = 喂？
 1	喂	喂	INTJ	_	_	0	root	_	SpaceAfter=No
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 287
+# parallel_id = hk/287
 # text = 我妹呢，有啲問題想問我呀。
 1	我	我	PRON	_	_	2	nmod	_	SpaceAfter=No
 2	妹	妹	NOUN	_	_	5	nsubj	_	SpaceAfter=No
@@ -2986,6 +3273,7 @@
 12	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 288
+# parallel_id = hk/288
 # text = 我想教咗佢先呀。
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	想	想	AUX	_	_	3	aux	_	SpaceAfter=No
@@ -2997,6 +3285,7 @@
 8	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 289
+# parallel_id = hk/289
 # text = 係呀，好煩㗎，佢。
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -3009,6 +3298,7 @@
 9	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 290
+# parallel_id = hk/290
 # text = 我轉頭搵你吖！
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	轉頭	轉頭	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -3018,6 +3308,7 @@
 6	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 291
+# parallel_id = hk/291
 # text = 哦，嗰度我識做㗎喇。
 1	哦	哦	INTJ	_	_	5	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	5	punct	_	SpaceAfter=No
@@ -3030,6 +3321,7 @@
 9	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 292
+# parallel_id = hk/292
 # text = ＯＫ，好，掰掰！
 1	ＯＫ	ＯＫ	VERB	_	_	0	root	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	3	punct	_	SpaceAfter=No
@@ -3039,6 +3331,7 @@
 6	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 293
+# parallel_id = hk/293
 # text = 喂！借餅帶嚟吖！
 1	喂	喂	INTJ	_	_	3	discourse	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -3050,6 +3343,7 @@
 8	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 294
+# parallel_id = hk/294
 # text = 唔得呀！
 1	唔	唔	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	得	得	VERB	_	_	0	root	_	SpaceAfter=No
@@ -3057,12 +3351,14 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 295
+# parallel_id = hk/295
 # text = 點解呀？
 1	點解	點解	ADV	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 296
+# parallel_id = hk/296
 # text = 我有個朋友八號生日呀！
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	有	有	VERB	_	_	0	root	_	SpaceAfter=No
@@ -3074,6 +3370,7 @@
 8	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 297
+# parallel_id = hk/297
 # text = 我想錄啲嘢畀佢。
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	想	想	AUX	_	_	3	aux	_	SpaceAfter=No
@@ -3085,6 +3382,7 @@
 8	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 298
+# parallel_id = hk/298
 # text = 關我咩事呀？
 1	關	關	VERB	_	_	0	root	_	SpaceAfter=No
 2	我	我	PRON	_	_	4	nmod	_	SpaceAfter=No
@@ -3094,6 +3392,7 @@
 6	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 299
+# parallel_id = hk/299
 # text = 喂，關乎到你有冇利是收個喎。
 1	喂	喂	INTJ	_	_	3	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -3109,11 +3408,13 @@
 12	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 300
+# parallel_id = hk/300
 # text = 喂！
 1	喂	喂	INTJ	_	_	0	root	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 301
+# parallel_id = hk/301
 # text = 嚇鬼咩？
 1	嚇	嚇	VERB	_	_	0	root	_	SpaceAfter=No
 2	鬼	鬼	NOUN	_	_	1	obj	_	SpaceAfter=No
@@ -3121,6 +3422,7 @@
 4	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 302
+# parallel_id = hk/302
 # text = 做咩呀，你？
 1	做	做	VERB	_	_	0	root	_	SpaceAfter=No
 2	咩	咩	PRON	_	_	1	obj	_	SpaceAfter=No
@@ -3130,6 +3432,7 @@
 6	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 303
+# parallel_id = hk/303
 # text = 刷你嘅牙啦！
 1	刷	刷	VERB	_	_	0	root	_	SpaceAfter=No
 2	你	你	PRON	_	_	4	nmod	_	SpaceAfter=No
@@ -3139,6 +3442,7 @@
 6	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 304
+# parallel_id = hk/304
 # text = 滴到周圍都係！
 1	滴	滴	VERB	_	_	0	root	_	SpaceAfter=No
 2	到	到	ADP	_	_	1	compound:ext	_	SpaceAfter=No
@@ -3148,6 +3452,7 @@
 6	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 305
+# parallel_id = hk/305
 # text = 刷完快啲瞓呀！
 1	刷	刷	VERB	_	_	5	advcl	_	SpaceAfter=No
 2	完	完	VERB	_	_	1	compound:vv	_	SpaceAfter=No
@@ -3158,11 +3463,13 @@
 7	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 306
+# parallel_id = hk/306
 # text = 過嚟！
 1	過嚟	過唻	VERB	_	_	0	root	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 307
+# parallel_id = hk/307
 # text = 又點呀？
 1	又	又	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	點	點	ADV	_	_	0	root	_	SpaceAfter=No
@@ -3170,6 +3477,7 @@
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 308
+# parallel_id = hk/308
 # text = 唔好咁嘈啦！
 1	唔好	唔好	AUX	_	_	3	aux	_	SpaceAfter=No
 2	咁	咁	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -3178,6 +3486,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 309
+# parallel_id = hk/309
 # text = 米嘈醒阿爺呀！
 1	米	米	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	嘈	嘈	VERB	_	_	0	root	_	SpaceAfter=No
@@ -3187,17 +3496,20 @@
 6	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 310
+# parallel_id = hk/310
 # text = 點唧？
 1	點	點	ADV	_	_	0	root	_	SpaceAfter=No
 2	唧	唧	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 311
+# parallel_id = hk/311
 # text = 計數！
 1	計數	計數	VERB	_	_	0	root	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 312
+# parallel_id = hk/312
 # text = 嗱，記住，每面三十分鐘。
 1	嗱	嗱	INTJ	_	_	3	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -3211,6 +3523,7 @@
 10	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 313
+# parallel_id = hk/313
 # text = 我揀歌呢，你計數。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	揀	揀	VERB	_	_	0	root	_	SpaceAfter=No
@@ -3222,6 +3535,7 @@
 8	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 314
+# parallel_id = hk/314
 # text = 中間唔要有空白呀，知唔知呀？
 1	中間	中間	NOUN	_	_	4	obl	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -3237,6 +3551,7 @@
 12	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 315
+# parallel_id = hk/315
 # text = 有冇着數先？
 1	有	有	VERB	_	_	0	root	_	SpaceAfter=No
 2	冇	冇	VERB	_	_	1	conj	_	SpaceAfter=No
@@ -3245,6 +3560,7 @@
 5	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 316
+# parallel_id = hk/316
 # text = 你試下唔幫我吖！
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	試	試	VERB	_	_	0	root	_	SpaceAfter=No
@@ -3256,6 +3572,7 @@
 8	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 317
+# parallel_id = hk/317
 # text = 打鑊你！
 1	打	打	VERB	_	_	0	root	_	SpaceAfter=No
 2	鑊	鑊	NOUN	_	NounType=Clf	1	obl	_	SpaceAfter=No
@@ -3263,6 +3580,7 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 318
+# parallel_id = hk/318
 # text = 記住，第一個，《抬起我的頭來》，三分廿一秒。
 1	記	記	VERB	_	_	0	root	_	SpaceAfter=No
 2	住	住	VERB	_	_	1	compound:vv	_	SpaceAfter=No
@@ -3281,6 +3599,7 @@
 15	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 319
+# parallel_id = hk/319
 # text = 等陣先，等陣先！
 1	等陣	等陣	VERB	_	_	0	root	_	SpaceAfter=No
 2	先	先	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -3290,12 +3609,14 @@
 6	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 320
+# parallel_id = hk/320
 # text = 第二個。
 1	第二	第二	ADJ	_	_	2	amod	_	SpaceAfter=No
 2	個	個	NOUN	_	NounType=Clf	0	root	_	SpaceAfter=No
 3	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 321
+# parallel_id = hk/321
 # text = 等陣先，等陣先！
 1	等陣	等陣	VERB	_	_	0	root	_	SpaceAfter=No
 2	先	先	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -3305,18 +3626,21 @@
 6	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 322
+# parallel_id = hk/322
 # text = 《黑夜不再來》
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No
 2	黑夜不再來	黑夜不再來	PROPN	_	_	0	root	_	SpaceAfter=No
 3	》	》	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 323
+# parallel_id = hk/323
 # text = 等陣呀！
 1	等陣	等陣	VERB	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 324
+# parallel_id = hk/324
 # text = 四分零五秒。
 1	四	四	NUM	_	_	2	nummod	_	SpaceAfter=No
 2	分	分	NOUN	_	NounType=Clf	0	root	_	SpaceAfter=No
@@ -3325,12 +3649,14 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 325
+# parallel_id = hk/325
 # text = 等陣呀！
 1	等陣	等陣	VERB	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 326
+# parallel_id = hk/326
 # text = 第一個幾多分呀？
 1	第一	第一	ADJ	_	_	2	amod	_	SpaceAfter=No
 2	個	個	NOUN	_	NounType=Clf	4	nsubj	_	SpaceAfter=No
@@ -3340,6 +3666,7 @@
 6	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 327
+# parallel_id = hk/327
 # text = 三分廿一呀。
 1	三	三	NUM	_	_	2	nummod	_	SpaceAfter=No
 2	分	分	NOUN	_	NounType=Clf	0	root	_	SpaceAfter=No
@@ -3348,6 +3675,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 328
+# parallel_id = hk/328
 # text = 咩嚟㗎，咩嚟㗎，呢隻？
 1	咩	咩	PRON	_	_	0	root	_	SpaceAfter=No
 2	嚟	唻	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -3362,6 +3690,7 @@
 11	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 329
+# parallel_id = hk/329
 # text = 《夏天的故事》之後，阿哥就冇再買過Eason以外嘅碟。
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No
 2	夏天的故事	夏天的故事	PROPN	_	_	10	obl	_	SpaceAfter=No
@@ -3381,6 +3710,7 @@
 16	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 330
+# parallel_id = hk/330
 # text = 其實我都唔明，點解阿哥唔直接送千嬅隻碟畀佢朋友。
 1	其實	其實	ADV	_	_	5	advmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	5	nsubj	_	SpaceAfter=No
@@ -3402,6 +3732,7 @@
 18	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 331
+# parallel_id = hk/331
 # text = 但我覺得嗰晚，我哋做咗件好型好浪漫嘅事。
 1	但	但	CCONJ	_	_	3	advmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -3422,12 +3753,14 @@
 17	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 332
+# parallel_id = hk/332
 # text = 執嘢！
 1	執	執	VERB	_	_	0	root	_	SpaceAfter=No
 2	嘢	嘢	NOUN	_	_	1	obj	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 333
+# parallel_id = hk/333
 # text = 呀！我要聽《森美小儀dotdotdot》呀！
 1	呀	呀	INTJ	_	_	5	discourse	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -3441,6 +3774,7 @@
 10	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 334
+# parallel_id = hk/334
 # text = 九零三，九零三吖！快啲啦！
 1	九零三	九零三	PROPN	_	_	0	root	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -3453,12 +3787,14 @@
 9	！	！	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 335
+# parallel_id = hk/335
 # text = 等等啦！
 1	等等	等等	VERB	_	_	0	root	_	SpaceAfter=No
 2	啦	喇	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 336
+# parallel_id = hk/336
 # text = 快啲啦！
 1	快	快	ADJ	_	_	0	root	_	SpaceAfter=No
 2	啲	啲	ADV	_	_	1	advmod	_	SpaceAfter=No
@@ -3466,6 +3802,7 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 337
+# parallel_id = hk/337
 # text = 呢首你咪錄咗囖。
 1	呢	呢	DET	_	_	2	det	_	SpaceAfter=No
 2	首	首	NOUN	_	NounType=Clf	5	obj:periph	_	SpaceAfter=No
@@ -3477,12 +3814,14 @@
 8	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 338
+# parallel_id = hk/338
 # text = 又聽？
 1	又	又	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	聽	聽	VERB	_	_	0	root	_	SpaceAfter=No
 3	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 339
+# parallel_id = hk/339
 # text = 呢個係九零三嚟㗎喇喎。
 1	呢	呢	DET	_	_	2	det	_	SpaceAfter=No
 2	個	個	NOUN	_	NounType=Clf	4	nsubj	_	SpaceAfter=No
@@ -3495,6 +3834,7 @@
 9	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 340
+# parallel_id = hk/340
 # text = 你睇下啦。
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	睇	睇	VERB	_	_	0	root	_	SpaceAfter=No
@@ -3503,6 +3843,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 341
+# parallel_id = hk/341
 # text = 哦，收唔到喇。
 1	哦	哦	INTJ	_	_	3	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	3	punct	_	SpaceAfter=No
@@ -3513,6 +3854,7 @@
 7	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 342
+# parallel_id = hk/342
 # text = 你搞返掂佢呀。
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	搞	搞	VERB	_	_	0	root	_	SpaceAfter=No
@@ -3523,6 +3865,7 @@
 7	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 343
+# parallel_id = hk/343
 # text = 你過去收吖。
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	過去	過去	VERB	_	_	0	root	_	SpaceAfter=No
@@ -3531,6 +3874,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 344
+# parallel_id = hk/344
 # text = 都唔得喎。
 1	都	都	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -3539,6 +3883,7 @@
 5	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 345
+# parallel_id = hk/345
 # text = 舉高佢吖。
 1	舉	舉	VERB	_	_	0	root	_	SpaceAfter=No
 2	高	高	ADJ	_	_	1	compound:vv	_	SpaceAfter=No
@@ -3547,6 +3892,7 @@
 5	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 346
+# parallel_id = hk/346
 # text = 你試下將條天線㨃出出便。
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	試	試	VERB	_	_	0	root	_	SpaceAfter=No
@@ -3560,6 +3906,7 @@
 10	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 347
+# parallel_id = hk/347
 # text = 都唔得喎。
 1	都	都	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -3568,6 +3915,7 @@
 5	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 348
+# parallel_id = hk/348
 # text = 你行去另一便試下。
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	行	行	VERB	_	_	0	root	_	SpaceAfter=No
@@ -3580,6 +3928,7 @@
 9	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 349
+# parallel_id = hk/349
 # text = 轉個圈啦，不如。
 1	轉	轉	VERB	_	_	0	root	_	SpaceAfter=No
 2	個	個	NOUN	_	NounType=Clf	3	clf:det	_	SpaceAfter=No
@@ -3590,6 +3939,7 @@
 7	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 350
+# parallel_id = hk/350
 # text = 跳兩步啦，試下。
 1	跳	跳	VERB	_	_	6	ccomp	_	SpaceAfter=No
 2	兩	兩	NUM	_	_	3	nummod	_	SpaceAfter=No
@@ -3601,6 +3951,7 @@
 8	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 351
+# parallel_id = hk/351
 # text = 再舉高先跳吖。
 1	再	再	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	舉	舉	VERB	_	_	4	advcl	_	SpaceAfter=No
@@ -3611,6 +3962,7 @@
 7	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 352
+# parallel_id = hk/352
 # text = 再舉高。
 1	再	再	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	舉	舉	VERB	_	_	0	root	_	SpaceAfter=No
@@ -3618,6 +3970,7 @@
 4	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 353
+# parallel_id = hk/353
 # text = 高啲，再高啲！係啦，跳啦！
 1	高	高	ADJ	_	_	0	root	_	SpaceAfter=No
 2	啲	啲	ADV	_	_	1	advmod	_	SpaceAfter=No
@@ -3634,6 +3987,7 @@
 13	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 354
+# parallel_id = hk/354
 # text = 你究竟要我做幾多次呀？
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	究竟	究竟	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -3646,6 +4000,7 @@
 9	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 355
+# parallel_id = hk/355
 # text = 好重呀！
 1	好	好	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	重	重	ADJ	_	_	0	root	_	SpaceAfter=No
@@ -3653,6 +4008,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 356
+# parallel_id = hk/356
 # text = 你而家last-touch喎。
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	而家	而家	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No
@@ -3661,6 +4017,7 @@
 5	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 357
+# parallel_id = hk/357
 # text = 你整壞㗎喎。
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	整	整	VERB	_	_	0	root	_	SpaceAfter=No
@@ -3670,6 +4027,7 @@
 6	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 358
+# parallel_id = hk/358
 # text = 你搞返掂佢呀。
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	搞	搞	VERB	_	_	0	root	_	SpaceAfter=No
@@ -3680,6 +4038,7 @@
 7	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 359
+# parallel_id = hk/359
 # text = 關我咩事喎？
 1	關	關	VERB	_	_	0	root	_	SpaceAfter=No
 2	我	我	PRON	_	_	4	nmod	_	SpaceAfter=No
@@ -3689,6 +4048,7 @@
 6	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 360
+# parallel_id = hk/360
 # text = 呢句得喎！
 1	呢	呢	DET	_	_	2	det	_	SpaceAfter=No
 2	句	句	NOUN	_	NounType=Clf	3	nsubj	_	SpaceAfter=No
@@ -3697,6 +4057,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 361
+# parallel_id = hk/361
 # text = 繼續講吖！
 1	繼續	繼續	VERB	_	_	0	root	_	SpaceAfter=No
 2	講	講	VERB	_	_	1	xcomp	_	SpaceAfter=No
@@ -3704,6 +4065,7 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 362
+# parallel_id = hk/362
 # text = 關我咩事喎？
 1	關	關	VERB	_	_	0	root	_	SpaceAfter=No
 2	我	我	PRON	_	_	4	nmod	_	SpaceAfter=No
@@ -3713,6 +4075,7 @@
 6	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 363
+# parallel_id = hk/363
 # text = 繼續講啦！係啦，係啦，繼續講！講快啲啦！
 1	繼續	繼續	VERB	_	_	0	root	_	SpaceAfter=No
 2	講	講	VERB	_	_	1	xcomp	_	SpaceAfter=No
@@ -3734,6 +4097,7 @@
 18	！	！	PUNCT	_	_	14	punct	_	SpaceAfter=No
 
 # sent_id = 364
+# parallel_id = hk/364
 # text = 關我咩事喎？
 1	關	關	VERB	_	_	0	root	_	SpaceAfter=No
 2	我	我	PRON	_	_	4	nmod	_	SpaceAfter=No
@@ -3743,6 +4107,7 @@
 6	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 365
+# parallel_id = hk/365
 # text = 快啲，快啲，快啲！
 1	快	快	ADJ	_	_	0	root	_	SpaceAfter=No
 2	啲	啲	ADV	_	_	1	advmod	_	SpaceAfter=No
@@ -3755,6 +4120,7 @@
 9	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 366
+# parallel_id = hk/366
 # text = 關我咩事喎？
 1	關	關	VERB	_	_	0	root	_	SpaceAfter=No
 2	我	我	PRON	_	_	4	nmod	_	SpaceAfter=No
@@ -3764,11 +4130,13 @@
 6	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 367
+# parallel_id = hk/367
 # text = 喂！
 1	喂	喂	INTJ	_	_	0	root	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 368
+# parallel_id = hk/368
 # text = 有咩好笑？
 1	有	有	VERB	_	_	0	root	_	SpaceAfter=No
 2	咩	咩	DET	_	_	1	obj	_	SpaceAfter=No
@@ -3776,6 +4144,7 @@
 4	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 369
+# parallel_id = hk/369
 # text = 唔好咁大聲啦！
 1	唔好	唔好	AUX	_	_	3	aux	_	SpaceAfter=No
 2	咁	咁	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -3784,6 +4153,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 370
+# parallel_id = hk/370
 # text = 嘈醒人哋喇！
 1	嘈	嘈	VERB	_	_	0	root	_	SpaceAfter=No
 2	醒	醒	VERB	_	_	1	compound:vv	_	SpaceAfter=No
@@ -3792,6 +4162,7 @@
 5	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 371
+# parallel_id = hk/371
 # text = 唔好咁大聲呀！
 1	唔好	唔好	AUX	_	_	3	aux	_	SpaceAfter=No
 2	咁	咁	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -3800,6 +4171,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 372
+# parallel_id = hk/372
 # text = 你啲拖鞋達達聲嘈醒阿爺呀！
 1	你	你	PRON	_	_	4	nmod	_	SpaceAfter=No
 2	啲	啲	DET	_	_	3	det	_	SpaceAfter=No
@@ -3812,6 +4184,7 @@
 9	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 373
+# parallel_id = hk/373
 # text = 唔好嘈喇！
 1	唔好	唔好	AUX	_	_	2	aux	_	SpaceAfter=No
 2	嘈	嘈	VERB	_	_	0	root	_	SpaceAfter=No
@@ -3819,6 +4192,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 374
+# parallel_id = hk/374
 # text = 噉唔通唔着咩？
 1	噉	噉	ADV	_	_	4	discourse	_	SpaceAfter=No
 2	唔通	唔通	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -3828,11 +4202,13 @@
 6	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 375
+# parallel_id = hk/375
 # text = 咩話？
 1	咩話	咩話	VERB	_	_	0	root	_	SpaceAfter=No
 2	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 376
+# parallel_id = hk/376
 # text = 噉唔通唔着咩？
 1	噉	噉	ADV	_	_	4	discourse	_	SpaceAfter=No
 2	唔通	唔通	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -3842,6 +4218,7 @@
 6	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 377
+# parallel_id = hk/377
 # text = 再大聲，嘈醒阿爺，起身丙你吖嘛，知唔知呀，吓？
 1	再	再	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	大聲	大聲	ADJ	_	_	0	root	_	SpaceAfter=No
@@ -3864,12 +4241,14 @@
 19	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 378
+# parallel_id = hk/378
 # text = 唔知。
 1	唔	唔	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	知	知	VERB	_	_	0	root	_	SpaceAfter=No
 3	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 379
+# parallel_id = hk/379
 # text = 你想我代阿爺丙你呀，吓？
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	想	想	VERB	_	_	0	root	_	SpaceAfter=No
@@ -3884,6 +4263,7 @@
 11	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 380
+# parallel_id = hk/380
 # text = 仲嘈呀馬？
 1	仲	仲	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	嘈	嘈	VERB	_	_	0	root	_	SpaceAfter=No
@@ -3891,6 +4271,7 @@
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 381
+# parallel_id = hk/381
 # text = 坐低啦，好唔好呀？
 1	坐	坐	VERB	_	_	0	root	_	SpaceAfter=No
 2	低	低	ADJ	_	_	1	compound:vv	_	SpaceAfter=No
@@ -3903,12 +4284,14 @@
 9	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 382
+# parallel_id = hk/382
 # text = 唔好。
 1	唔	唔	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	好	好	ADJ	_	_	0	root	_	SpaceAfter=No
 3	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 383
+# parallel_id = hk/383
 # text = 吖，死𡃁妹吖！
 1	吖	吖	PART	_	_	3	discourse:sp	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -3917,6 +4300,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 384
+# parallel_id = hk/384
 # text = 真係要我教訓，係咪呀？
 1	真係	真係	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	要	要	VERB	_	_	0	root	_	SpaceAfter=No
@@ -3928,6 +4312,7 @@
 8	？	？	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 385
+# parallel_id = hk/385
 # text = 快啲，扭開收音機過去再跳過！
 1	快	快	ADJ	_	_	0	root	_	SpaceAfter=No
 2	啲	啲	ADV	_	_	1	advmod	_	SpaceAfter=No
@@ -3942,6 +4327,7 @@
 11	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 386
+# parallel_id = hk/386
 # text = 阿哥呀，我今日扭倒㗎！
 1	阿哥	阿哥	NOUN	_	_	6	vocative	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -3954,6 +4340,7 @@
 9	！	！	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 387
+# parallel_id = hk/387
 # text = 送畀你送畀你個朋友吖！
 1	送	送	VERB	_	_	0	root	_	SpaceAfter=No
 2	畀	畀	ADP	_	_	3	case	_	SpaceAfter=No
@@ -3967,6 +4354,7 @@
 10	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 388
+# parallel_id = hk/388
 # text = 幫我同佢講「生日快樂」吖！
 1	幫	幫	VERB	_	_	0	root	_	SpaceAfter=No
 2	我	我	PRON	_	_	1	obj	_	SpaceAfter=No
@@ -3980,12 +4368,14 @@
 10	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 389
+# parallel_id = hk/389
 # text = 唔使喇。
 1	唔使	唔使	AUX	_	_	0	root	_	SpaceAfter=No
 2	喇	嘑	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 390
+# parallel_id = hk/390
 # text = 喂呀，特登同李嘉祺換㗎！
 1	喂	喂	INTJ	_	_	7	discourse	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -3998,6 +4388,7 @@
 9	！	！	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 391
+# parallel_id = hk/391
 # text = 都千禧年啦，邊有人用錄音帶𠿪？
 1	都	都	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	千禧年	千禧年	NOUN	_	_	0	root	_	SpaceAfter=No
@@ -4012,11 +4403,13 @@
 11	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 392
+# parallel_id = hk/392
 # text = 傻仔！
 1	傻仔	傻仔	NOUN	_	_	0	root	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 393
+# parallel_id = hk/393
 # text = 係咪呢餅呀？
 1	係咪	係咪	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	呢	呢	DET	_	_	3	det	_	SpaceAfter=No
@@ -4025,6 +4418,7 @@
 5	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 394
+# parallel_id = hk/394
 # text = 嗯！係呀，係呀，呢餅呀！
 1	嗯	嗯	INTJ	_	_	3	discourse	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -4040,60 +4434,70 @@
 12	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 395
+# parallel_id = hk/395
 # text = 《抬起我的頭來》
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No
 2	抬起我的頭來	抬起我的頭來	PROPN	_	_	0	root	_	SpaceAfter=No
 3	》	》	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 396
+# parallel_id = hk/396
 # text = 《今天等我來》
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No
 2	今天等我來	今天等我來	PROPN	_	_	0	root	_	SpaceAfter=No
 3	》	》	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 397
+# parallel_id = hk/397
 # text = 《不再讓你孤單》
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No
 2	不再讓你孤單	不再讓你孤單	PROPN	_	_	0	root	_	SpaceAfter=No
 3	》	》	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 398
+# parallel_id = hk/398
 # text = 《今日》
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No
 2	今日	今日	NOUN	_	_	0	root	_	SpaceAfter=No
 3	》	》	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 399
+# parallel_id = hk/399
 # text = 《每一個明天》
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No
 2	每一個明天	每一個明天	PROPN	_	_	0	root	_	SpaceAfter=No
 3	》	》	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 400
+# parallel_id = hk/400
 # text = 《夏天的故事》
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No
 2	夏天的故事	夏天的故事	PROPN	_	_	0	root	_	SpaceAfter=No
 3	》	》	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 401
+# parallel_id = hk/401
 # text = 《伴遊》
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No
 2	伴遊	伴遊	PROPN	_	_	0	root	_	SpaceAfter=No
 3	》	》	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 402
+# parallel_id = hk/402
 # text = 《與我常在》
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No
 2	與我常在	與我常在	PROPN	_	_	0	root	_	SpaceAfter=No
 3	》	》	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 403
+# parallel_id = hk/403
 # text = 《有發生過》
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No
 2	有發生過	有發生過	PROPN	_	_	0	root	_	SpaceAfter=No
 3	》	》	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 404
+# parallel_id = hk/404
 # text = 咩呀？童年經典──龍珠主題曲。
 1	咩	咩	PRON	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -4106,6 +4510,7 @@
 9	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 405
+# parallel_id = hk/405
 # text = 怪唔之得追唔倒女仔啦！
 1	怪唔之得	怪唔之得	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	追	追	VERB	_	_	0	root	_	SpaceAfter=No
@@ -4116,6 +4521,7 @@
 7	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 406
+# parallel_id = hk/406
 # text = 欸，嗰部機仲喺唔喺度呀？
 1	欸	欸	INTJ	_	_	7	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -4130,11 +4536,13 @@
 11	？	？	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 407
+# parallel_id = hk/407
 # text = 喺度。
 1	喺度	喺度	VERB	_	_	0	root	_	SpaceAfter=No
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 408
+# parallel_id = hk/408
 # text = 吓，噉都畀你搵到呀？
 1	吓	吓	INTJ	_	_	5	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -4148,6 +4556,7 @@
 10	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 409
+# parallel_id = hk/409
 # text = 點會係呢啲嘢？
 1	點	點	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	會	會	AUX	_	_	3	aux	_	SpaceAfter=No
@@ -4157,6 +4566,7 @@
 6	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 410
+# parallel_id = hk/410
 # text = 你睇下，佢成日都蝦我！
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	睇	睇	VERB	_	_	0	root	_	SpaceAfter=No
@@ -4170,6 +4580,7 @@
 10	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 411
+# parallel_id = hk/411
 # text = 每一個歌手呢，都有一個藝名，有一個唱歌嘅名嚟嘅，藝名嚟嘅。
 1	每	每	DET	_	_	4	det	_	SpaceAfter=No|Translit=mui5|Gloss=every
 2	一	一	NUM	_	_	4	nummod	_	SpaceAfter=No|Translit=yat1|Gloss=one
@@ -4198,6 +4609,7 @@
 25	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 412
+# parallel_id = hk/412
 # text = 哎唷，哎吔，呢個冇人贊成嘅。
 1	哎唷	哎唷	INTJ	_	_	6	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -4211,6 +4623,7 @@
 10	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 413
+# parallel_id = hk/413
 # text = 因為-因為我呢個年紀嘅人，好似呢個年紀嘅人，應該喺屋企帶孫，有孫嘛，可？帶孫呀，煮飯買菜呀。
 1	因為	因為	ADV	_	_	3	reparandum	_	SpaceAfter=No
 2	-	-	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -4249,6 +4662,7 @@
 35	。	。	PUNCT	_	_	29	punct	_	SpaceAfter=No
 
 # sent_id = 414
+# parallel_id = hk/414
 # text = 我唔係嗰種性格，我係中意响出面玩嘅性格。
 1	我	我	PRON	_	_	6	nsubj	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	6	advmod	_	SpaceAfter=No
@@ -4268,6 +4682,7 @@
 16	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 415
+# parallel_id = hk/415
 # text = 我對呢個-唱歌好有興趣嘅。
 1	我	我	PRON	_	_	8	nsubj	_	SpaceAfter=No
 2	對	對	ADP	_	_	6	case	_	SpaceAfter=No
@@ -4282,6 +4697,7 @@
 11	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 416
+# parallel_id = hk/416
 # text = 初初呢，就由唱歌而-而嚟嘅，噉，後尾呢，唱唱下，中意做嘞。
 1	初初	初初	ADV	_	_	10	advmod	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -4308,6 +4724,7 @@
 23	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 417
+# parallel_id = hk/417
 # text = 噉呀，噉，有啲人退咗休就頂畀我。噉就頂嚟做囖。
 1	噉	噉	ADV	_	_	6	discourse	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -4334,6 +4751,7 @@
 23	。	。	PUNCT	_	_	19	punct	_	SpaceAfter=No
 
 # sent_id = 418
+# parallel_id = hk/418
 # text = 唱歌咪可以誒，抒發自己內心嘅，唔開心嘅嘢啦，下，或者又抒發自己開心嘅嘢啦，係。
 1	唱歌	唱歌	VERB	_	_	6	csubj	_	SpaceAfter=No
 2	咪	咪	ADV	_	_	6	advmod	_	SpaceAfter=No
@@ -4366,6 +4784,7 @@
 29	。	。	PUNCT	_	_	21	punct	_	SpaceAfter=No
 
 # sent_id = 419
+# parallel_id = hk/419
 # text = 使唔使我呀，幫手呀，ei1。
 1	使	使	VERB	_	_	0	root	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -4380,6 +4799,7 @@
 11	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 420
+# parallel_id = hk/420
 # text = 去咗邊度呀，佢？
 1	去	去	VERB	_	_	0	root	_	SpaceAfter=No
 2	咗	咗	AUX	_	_	1	aux	_	SpaceAfter=No
@@ -4390,6 +4810,7 @@
 7	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 421
+# parallel_id = hk/421
 # text = 可以點叫我呀？呢度成條街叫我大家姐，因為我最大，年紀最大吖嘛。
 1	可以	可以	AUX	_	_	3	aux	_	SpaceAfter=No
 2	點	點	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -4417,6 +4838,7 @@
 24	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 422
+# parallel_id = hk/422
 # text = 我姓湯，不過啲人成條街都唔知道我姓湯，冇人知道我叫咩名嘅。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	姓	姓	VERB	_	_	0	root	_	SpaceAfter=No
@@ -4446,6 +4868,7 @@
 26	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 423
+# parallel_id = hk/423
 # text = 幫人做咗幾年喇，做咗幾年。後尾，ei1做，誒做咗幾年呢。
 1	幫	幫	VERB	_	_	0	root	_	SpaceAfter=No
 2	人	人	NOUN	_	_	1	obj	_	SpaceAfter=No
@@ -4474,6 +4897,7 @@
 25	。	。	PUNCT	_	_	20	punct	_	SpaceAfter=No
 
 # sent_id = 424
+# parallel_id = hk/424
 # text = 我老世炒我魷魚，我好多謝個老世呀，佢炒咗我魷魚嘛。
 1	我	我	PRON	_	_	2	nmod	_	SpaceAfter=No
 2	老世	老世	NOUN	_	_	3	nsubj	_	SpaceAfter=No
@@ -4497,6 +4921,7 @@
 20	。	。	PUNCT	_	_	15	punct	_	SpaceAfter=No
 
 # sent_id = 425
+# parallel_id = hk/425
 # text = 若果佢唔炒我魷魚呢，我自己就開唔到呢一度。
 1	若果	若果	SCONJ	_	_	4	mark	_	SpaceAfter=No
 2	佢	佢	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -4518,6 +4943,7 @@
 18	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No
 
 # sent_id = 426
+# parallel_id = hk/426
 # text = 噉呢，佢炒咗我嘞。剛好呢度嘅老世呢，佢又好忙，做唔嚟，打理唔過嚟，佢有其他地方。
 1	噉	噉	ADV	_	_	5	discourse	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -4554,6 +4980,7 @@
 33	。	。	PUNCT	_	_	19	punct	_	SpaceAfter=No
 
 # sent_id = 427
+# parallel_id = hk/427
 # text = 我睇中呢個老世做唔嚟。我叫佢：「不如誒，呢啲檯檯凳凳頂畀我做。」喺度做，我先做咗一年半。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	睇	睇	VERB	_	_	0	root	_	SpaceAfter=No
@@ -4595,6 +5022,7 @@
 38	。	。	PUNCT	_	_	33	punct	_	SpaceAfter=No
 
 # sent_id = 428
+# parallel_id = hk/428
 # text = 講你聽吖：你哋啲後生仔，我係過嚟人。
 1	講	講	VERB	_	_	0	root	_	SpaceAfter=No
 2	你	你	PRON	_	_	1	obj	_	SpaceAfter=No
@@ -4611,6 +5039,7 @@
 13	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No
 
 # sent_id = 429
+# parallel_id = hk/429
 # text = 係要幫人打工㗎！打咗工又有經驗喇，自己搞掂。
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	要	要	AUX	_	_	3	aux	_	SpaceAfter=No
@@ -4632,11 +5061,13 @@
 18	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 430
+# parallel_id = hk/430
 # text = 天生我材必有用。
 1	天生我材必有用	天生我材必有用	VERB	_	_	0	root	_	SpaceAfter=No
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 431
+# parallel_id = hk/431
 # text = 讀多啲書自然就有用；學多咗嘢自然就有用。
 1	讀	讀	VERB	_	_	7	advcl	_	SpaceAfter=No
 2	多	多	ADJ	_	_	4	amod	_	SpaceAfter=No
@@ -4656,6 +5087,7 @@
 16	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 432
+# parallel_id = hk/432
 # text = 係咪噉呀？我教我個女，真係噉教呀。
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	咪	咪	VERB	_	_	1	conj	_	SpaceAfter=No
@@ -4676,6 +5108,7 @@
 17	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 433
+# parallel_id = hk/433
 # text = 我得一個女，冇仔。
 1	我	我	PRON	_	_	5	nsubj	_	SpaceAfter=No
 2	得	得	ADV	_	_	5	advmod	_	SpaceAfter=No
@@ -4688,11 +5121,13 @@
 9	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 434
+# parallel_id = hk/434
 # text = 天生我材必有用。
 1	天生我材必有用	天生我材必有用	VERB	_	_	0	root	_	SpaceAfter=No
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 435
+# parallel_id = hk/435
 # text = 即係點樣呀？係動聽。
 1	即係	即係	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	點樣	點樣	ADV	_	_	0	root	_	SpaceAfter=No
@@ -4703,6 +5138,7 @@
 7	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 436
+# parallel_id = hk/436
 # text = 依個，全部都自-自發性嘅。早諗起嗰首歌，係嗰首歌可以舒緩我自己嘅。
 1	依個	依個	PRON	_	_	7	nsubj	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -4731,6 +5167,7 @@
 25	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 437
+# parallel_id = hk/437
 # text = 我唱下呢個誒，男兒當自強，下嘛，幾雄壯呀。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	唱	唱	VERB	_	_	0	root	_	SpaceAfter=No
@@ -4749,6 +5186,7 @@
 15	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 438
+# parallel_id = hk/438
 # text = 或者個key唔啱呃，佢都可以唱，嚟發洩自己。
 1	或者	或者	ADV	_	_	5	advmod	_	SpaceAfter=No
 2	個	個	NOUN	_	NounType=Clf	3	clf:det	_	SpaceAfter=No
@@ -4768,6 +5206,7 @@
 16	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 439
+# parallel_id = hk/439
 # text = 所以歌檔就係噉樣嚟嘅。係畀啲大家勞動者呀，勞動階級，呀……有陣時就有啲旅客呀，旅客即係旅遊人士呀。啲西人呀，佢都落嚟捧場㗎，啲西人。
 1	所以	所以	ADV	_	_	6	advmod	_	SpaceAfter=No
 2	歌檔	歌檔	NOUN	_	_	4	nsubj	_	SpaceAfter=No
@@ -4817,6 +5256,7 @@
 46	。	。	PUNCT	_	_	39	punct	_	SpaceAfter=No
 
 # sent_id = 440
+# parallel_id = hk/440
 # text = 好似呢個檔係彈琴嘅。我唔跟人哋，唔學人哋。要創新嘛，可？做咩要學人哋彈琴呢？
 1	好似	好似	ADV	_	_	6	advmod	_	SpaceAfter=No
 2	呢	呢	DET	_	_	4	det	_	SpaceAfter=No
@@ -4850,6 +5290,7 @@
 30	？	？	PUNCT	_	_	26	punct	_	SpaceAfter=No
 
 # sent_id = 441
+# parallel_id = hk/441
 # text = 我就要搞卡拉ＯＫ，琴師都唔使。
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No
 2	就	就	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -4864,6 +5305,7 @@
 11	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 442
+# parallel_id = hk/442
 # text = 我-我唔拉人哋嘅電。你睇人哋有-就攞電，呀，我攞發電機。
 1	我	我	PRON	_	_	3	reparandum	_	SpaceAfter=No
 2	-	-	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -4891,6 +5333,7 @@
 24	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 443
+# parallel_id = hk/443
 # text = 其實呢度就落雨，個電工唔畀電，佢哋就冇電嘞。
 1	其實	其實	ADV	_	_	14	advmod	_	SpaceAfter=No
 2	呢度	呢度	PRON	_	_	14	obl	_	SpaceAfter=No
@@ -4911,6 +5354,7 @@
 17	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No
 
 # sent_id = 444
+# parallel_id = hk/444
 # text = 我自己攞發電機，係咪我就有電喇，呀。
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	自己	自己	PRON	_	_	3	advcl	_	SpaceAfter=No
@@ -4928,6 +5372,7 @@
 14	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 445
+# parallel_id = hk/445
 # text = 不過我一個女人，拉電嘅體力真係有限。拉唔郁嘅，拉唔到，搵啲工人拉。
 1	不過	不過	CCONJ	_	_	12	advmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	12	dislocated	_	SpaceAfter=No
@@ -4958,6 +5403,7 @@
 27	。	。	PUNCT	_	_	23	punct	_	SpaceAfter=No
 
 # sent_id = 446
+# parallel_id = hk/446
 # text = 我做呢行呢，啲脾氣全部變晒呀。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	做	做	VERB	_	_	10	advcl	_	SpaceAfter=No
@@ -4974,6 +5420,7 @@
 13	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 447
+# parallel_id = hk/447
 # text = 好火爆，都要變到好溫柔，好可愛。
 1	好	好	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	火爆	火爆	ADJ	_	_	6	advcl	_	SpaceAfter=No
@@ -4990,6 +5437,7 @@
 13	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 448
+# parallel_id = hk/448
 # text = 對人好，人哋對我好，係咪呀？
 1	對	對	VERB	_	_	3	advcl:coverb	_	SpaceAfter=No
 2	人	人	NOUN	_	_	1	obj	_	SpaceAfter=No
@@ -5005,6 +5453,7 @@
 12	？	？	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 449
+# parallel_id = hk/449
 # text = 每天對住啲人又笑，人哋肯幫你咖嘛。
 1	每	每	DET	_	_	2	det	_	SpaceAfter=No
 2	天	天	NOUN	_	NounType=Clf	7	obl	_	SpaceAfter=No
@@ -5022,6 +5471,7 @@
 14	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 450
+# parallel_id = hk/450
 # text = 對即使啲乞兒呀，呢啲，呀，飲醉酒、醉貓呀，喺呢度飲醉酒呀，或者乞兒好臭呀，我都唔鬧佢哋嘅，照坐。
 1	對	對	VERB	_	_	35	advcl:coverb	_	SpaceAfter=No
 2	即使	即使	SCONJ	_	_	4	mark	_	SpaceAfter=No
@@ -5066,6 +5516,7 @@
 41	。	。	PUNCT	_	_	35	punct	_	SpaceAfter=No
 
 # sent_id = 451
+# parallel_id = hk/451
 # text = 有人氣即是有財氣；有咗財氣先有-有福氣，哦。有咗福氣咪就有運氣囖，可。
 1	有	有	VERB	_	_	4	csubj	_	SpaceAfter=No
 2	人氣	人氣	NOUN	_	_	1	obj	_	SpaceAfter=No
@@ -5097,6 +5548,7 @@
 28	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 452
+# parallel_id = hk/452
 # text = 啲屋企人有冇話：「哎吔，唔好開歌檔呀，好大壓力呀。」
 1	啲	啲	NOUN	_	NounType=Clf	2	clf:det	_	SpaceAfter=No
 2	屋企人	屋企人	NOUN	_	_	5	nsubj	_	SpaceAfter=No
@@ -5120,6 +5572,7 @@
 20	」	」	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 453
+# parallel_id = hk/453
 # text = 哎唷，哎吔，呢個冇人贊成嘅。
 1	哎唷	哎唷	INTJ	_	_	7	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -5133,6 +5586,7 @@
 10	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 454
+# parallel_id = hk/454
 # text = 因為-因為我呢個年紀嘅人，好似呢個年紀嘅人，應該喺屋企帶孫，有孫嘛，可？帶孫呀，煮飯買菜呀。
 1	因為	因為	ADV	_	_	3	reparandum	_	SpaceAfter=No
 2	-	-	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -5171,6 +5625,7 @@
 35	。	。	PUNCT	_	_	29	punct	_	SpaceAfter=No
 
 # sent_id = 455
+# parallel_id = hk/455
 # text = 我唔係嗰種性格，我係中意响出面玩嘅性格。唔中意响屋企做家務呀，帶細路仔嗰種性格。
 1	我	我	PRON	_	_	6	nsubj	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	6	advmod	_	SpaceAfter=No
@@ -5204,6 +5659,7 @@
 30	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 456
+# parallel_id = hk/456
 # text = 所以我做，冇人贊成我做嘅。係我自己，我-我呢個人唔聽人講嘅。
 1	所以	所以	ADV	_	_	7	advmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -5234,6 +5690,7 @@
 27	。	。	PUNCT	_	_	23	punct	_	SpaceAfter=No
 
 # sent_id = 457
+# parallel_id = hk/457
 # text = 多數唱張學友呀，張國榮，誒，Beyond。
 1	多數	多數	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	唱	唱	VERB	_	_	0	root	_	SpaceAfter=No
@@ -5248,6 +5705,7 @@
 11	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 458
+# parallel_id = hk/458
 # text = 誒……有-有-有一部分歌佢哋成日-呢度啲人成日唱嘅。
 1	誒	誒	INTJ	_	_	17	discourse	_	SpaceAfter=No
 2	……	……	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -5270,6 +5728,7 @@
 19	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 459
+# parallel_id = hk/459
 # text = 呀呀，好似話，《讓一切隨風》呀，幾乎日日都有人唱。
 1	呀	呀	PART	_	_	14	discourse	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse	_	SpaceAfter=No
@@ -5290,6 +5749,7 @@
 17	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No
 
 # sent_id = 460
+# parallel_id = hk/460
 # text = 《分飛燕》呀，日日都，好似呢排都有。
 1	《	《	PUNCT	_	_	2	punct	_	SpaceAfter=No
 2	分飛燕	分飛燕	PROPN	_	_	13	nsubj:periph	_	SpaceAfter=No
@@ -5307,6 +5767,7 @@
 14	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No
 
 # sent_id = 461
+# parallel_id = hk/461
 # text = 不過我呢度唔唱粵曲，呀，呢度，歌。
 1	不過	不過	CCONJ	_	_	5	advmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	5	nsubj	_	SpaceAfter=No
@@ -5323,6 +5784,7 @@
 13	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 462
+# parallel_id = hk/462
 # text = 呀，呀，又有人唱，都有人唱新歌呀。
 1	呀	呀	PART	_	_	6	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -5343,6 +5805,7 @@
 17	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 463
+# parallel_id = hk/463
 # text = 唱嗰啲，誒，誒，誒，誒，誒。《從不喜歡孤單一個》都有人唱呢啲。
 1	唱	唱	VERB	_	_	0	root	_	SpaceAfter=No
 2	嗰	嗰	DET	_	_	3	det	_	SpaceAfter=No
@@ -5369,6 +5832,7 @@
 23	。	。	PUNCT	_	_	19	punct	_	SpaceAfter=No
 
 # sent_id = 464
+# parallel_id = hk/464
 # text = 你以前做咩？
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	以前	以前	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No
@@ -5377,6 +5841,7 @@
 5	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 465
+# parallel_id = hk/465
 # text = 愾吔，做鬼咩！我以前電視臺就參加比賽，輸咗呢。
 1	愾吔	愾吔	INTJ	_	_	3	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -5397,6 +5862,7 @@
 17	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 466
+# parallel_id = hk/466
 # text = 八幾年嗰時參賽呀，因-不過入唔到圍，呀，喀喀喀喀。
 1	八幾年	八幾年	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No
 2	嗰時	嗰時	PRON	_	_	1	appos	_	SpaceAfter=No
@@ -5417,6 +5883,7 @@
 17	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 467
+# parallel_id = hk/467
 # text = 由細到大都中意唱歌嘅？
 1	由	由	ADP	_	_	2	case	_	SpaceAfter=No
 2	細	細	ADJ	_	_	7	obl	_	SpaceAfter=No
@@ -5429,6 +5896,7 @@
 9	？	？	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 468
+# parallel_id = hk/468
 # text = 係，細個到而家都係興趣，呢啲係興趣，下。
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -5447,6 +5915,7 @@
 15	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 469
+# parallel_id = hk/469
 # text = 但係發展唔到。
 1	但係	但係	CCONJ	_	_	2	advmod	_	SpaceAfter=No
 2	發展	發展	VERB	_	_	0	root	_	SpaceAfter=No
@@ -5455,6 +5924,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 470
+# parallel_id = hk/470
 # text = 我諗廿年前我都喺過呢度，噉就歌廳就有。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	諗	諗	VERB	_	_	0	root	_	SpaceAfter=No
@@ -5475,6 +5945,7 @@
 17	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 471
+# parallel_id = hk/471
 # text = 噉我-我跟住去咗夜總會，又唱咗一set。
 1	噉	噉	ADV	_	_	6	discourse	_	SpaceAfter=No
 2	我	我	PRON	_	_	6	reparandum	_	SpaceAfter=No
@@ -5493,6 +5964,7 @@
 15	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 472
+# parallel_id = hk/472
 # text = 噉就跟住又冇做嘞，冇做呢行，走咗去轉行做咗第二啲嘢，我做咗經紀之嘛。
 1	噉	噉	ADV	_	_	6	discourse	_	SpaceAfter=No
 2	就	就	ADV	_	_	6	advmod	_	SpaceAfter=No
@@ -5526,6 +5998,7 @@
 30	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 473
+# parallel_id = hk/473
 # text = 以前消費力-消費力高呀，而家冇呀。
 1	以前	以前	NOUN	_	_	5	obl:tmod	_	SpaceAfter=No
 2	消費力	消費力	NOUN	_	_	5	reparandum	_	SpaceAfter=No
@@ -5540,6 +6013,7 @@
 11	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 474
+# parallel_id = hk/474
 # text = 以前歌廳有個-有個箱嘅。
 1	以前	以前	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No
 2	歌廳	歌廳	NOUN	_	_	3	nsubj	_	SpaceAfter=No
@@ -5553,6 +6027,7 @@
 10	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 475
+# parallel_id = hk/475
 # text = 佢啲-掛住一個。
 1	佢	佢	PRON	_	_	4	nsubj	_	SpaceAfter=No
 2	啲	啲	NOUN	_	NounType=Clf	4	reparandum	_	SpaceAfter=No
@@ -5564,6 +6039,7 @@
 8	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 476
+# parallel_id = hk/476
 # text = 你就-啲人畀利是嘅，而家冇喎。
 1	你	你	PRON	_	_	5	reparandum	_	SpaceAfter=No
 2	就	就	ADV	_	_	1	advmod	_	SpaceAfter=No
@@ -5580,6 +6056,7 @@
 13	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 477
+# parallel_id = hk/477
 # text = 噉初初嗰時，都係覺得好難接受囉，跟住但係冇辦法。
 1	噉	噉	ADV	_	_	6	discourse	_	SpaceAfter=No
 2	初初	初初	ADV	_	_	6	advmod	_	SpaceAfter=No
@@ -5600,6 +6077,7 @@
 17	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 478
+# parallel_id = hk/478
 # text = 因為我啱啱嚟到香港，我都要生存咖嘛。
 1	因為	因為	ADV	_	_	4	advmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -5616,6 +6094,7 @@
 13	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 479
+# parallel_id = hk/479
 # text = 突然間覺得香港，哇，啲租又咁貴，呀，又有咩又咁貴，有咩咁貴，噉我都要……
 1	突然間	突然間	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	覺得	覺得	VERB	_	_	0	root	_	SpaceAfter=No
@@ -5650,6 +6129,7 @@
 31	……	……	PUNCT	_	_	30	punct	_	SpaceAfter=No
 
 # sent_id = 480
+# parallel_id = hk/480
 # text = 人哋都話，唉，你一定要融入香港呢個潮流囖，如果唔係，你-你冇得生存㗎喇。
 1	人哋	人哋	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	都	都	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -5680,6 +6160,7 @@
 27	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 481
+# parallel_id = hk/481
 # text = 我慢慢適應。
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	慢慢	慢慢	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -5687,6 +6168,7 @@
 4	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 482
+# parallel_id = hk/482
 # text = 我個-我藝名叫做金燕子，係呀，金燕子，係呀，係我喺廟街，呢個廟街嘅藝名-藝名嚟㗎。
 1	我	我	PRON	_	_	4	reparandum	_	SpaceAfter=No
 2	個	個	NOUN	_	NounType=Clf	1	clf:det	_	SpaceAfter=No
@@ -5721,6 +6203,7 @@
 31	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 483
+# parallel_id = hk/483
 # text = 每一個歌手都有一個藝名，有一個唱歌嘅名嚟嘅，藝名嚟嘅。
 1	每	每	DET	_	_	3	det	_	SpaceAfter=No
 2	一	一	NUM	_	_	3	nummod	_	SpaceAfter=No
@@ -5747,6 +6230,7 @@
 23	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 484
+# parallel_id = hk/484
 # text = 呀，我喺廟街呢個行業可能已經有十七年。
 1	呀	呀	INTJ	_	_	11	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -5764,6 +6248,7 @@
 14	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 485
+# parallel_id = hk/485
 # text = 因為廟街歌壇就係靠啲客打賞畀個歌手呀。
 1	因為	因為	ADV	_	_	9	advmod	_	SpaceAfter=No
 2	廟街	廟街	PROPN	_	_	3	compound	_	SpaceAfter=No
@@ -5781,6 +6266,7 @@
 14	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 486
+# parallel_id = hk/486
 # text = 例如我想點唱咩歌，呀，畀幾多錢你。一百或者二百，或者甚至乎三百。
 1	例如	例如	ADV	_	_	10	advmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -5806,6 +6292,7 @@
 22	。	。	PUNCT	_	_	15	punct	_	SpaceAfter=No
 
 # sent_id = 487
+# parallel_id = hk/487
 # text = 噉或者話，我想同你合唱呢首歌。噉我哋有個最低消費㗎。同一個歌手合唱呢，一定要畀一百蚊㗎。
 1	噉	噉	ADV	_	_	8	discourse	_	SpaceAfter=No
 2	或者話	或者話	CCONJ	_	_	8	advmod	_	SpaceAfter=No
@@ -5843,6 +6330,7 @@
 34	。	。	PUNCT	_	_	30	punct	_	SpaceAfter=No
 
 # sent_id = 488
+# parallel_id = hk/488
 # text = 噉嗰時我點解會入咗呢個行業呢。
 1	噉	噉	ADV	_	_	6	discourse	_	SpaceAfter=No
 2	嗰時	嗰時	PRON	_	_	6	obl:tmod	_	SpaceAfter=No
@@ -5858,6 +6346,7 @@
 12	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 489
+# parallel_id = hk/489
 # text = 因為我喺大陸嗰時呢，我都係，都係唱歌做歌手，歌-歌手㗎。
 1	因為	因為	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -5883,6 +6372,7 @@
 22	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No
 
 # sent_id = 490
+# parallel_id = hk/490
 # text = 噉，我嚟到香港呢，我都希望搵返我自己中意個行業做囖。
 1	噉	噉	ADV	_	_	4	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -5907,6 +6397,7 @@
 21	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No
 
 # sent_id = 491
+# parallel_id = hk/491
 # text = 噉咪，嚟到香港之後，就會去搵朋友啦，睇報紙啦。
 1	噉	噉	ADV	_	_	4	discourse	_	SpaceAfter=No
 2	咪	咪	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -5929,6 +6420,7 @@
 19	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 492
+# parallel_id = hk/492
 # text = 噉，終於有個朋友呢，佢介紹我去酒樓夜總會唱歌。
 1	噉	噉	ADV	_	_	4	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	4	punct	_	SpaceAfter=No
@@ -5948,6 +6440,7 @@
 16	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 493
+# parallel_id = hk/493
 # text = 噉，喺嗰度識咗嗰啲唱歌啲朋友啦。帶咗我入嚟廟街話：「哎，廟街都有歌唱㗎喎，誒但係嗰度啲唱歌就唔同嘞，係靠啲客打賞呀噉。」
 1	噉	噉	ADV	_	_	5	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -6002,6 +6495,7 @@
 51	」	」	PUNCT	_	_	27	punct	_	SpaceAfter=No
 
 # sent_id = 494
+# parallel_id = hk/494
 # text = 我嚟咗香港之後呢，香港啲朋友就同我講話：「你千祈要明白呀，你喺香港做歌手呢，同喺中國大陸做歌手係唔同㗎。」
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	嚟	唻	VERB	_	_	14	advcl	_	SpaceAfter=No
@@ -6046,6 +6540,7 @@
 41	」	」	PUNCT	_	_	38	punct	_	SpaceAfter=No
 
 # sent_id = 495
+# parallel_id = hk/495
 # text = 因為呢度啲歌手呢，要啲-係要陪啲客飲酒啦，傾偈啦，要睇你接唔接受倒囖。
 1	因為	因為	ADV	_	_	10	advmod	_	SpaceAfter=No
 2	呢度	呢度	PRON	_	_	4	nmod	_	SpaceAfter=No
@@ -6078,6 +6573,7 @@
 29	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 496
+# parallel_id = hk/496
 # text = 因為我哋不嬲唱歌都係自己一個舞台唱歌，唱完歌就走嘞，唔需要同啲客打招呼啦。
 1	因為	因為	ADV	_	_	6	advmod	_	SpaceAfter=No
 2	我哋	我哋	PRON	_	_	6	nsubj	_	SpaceAfter=No
@@ -6108,6 +6604,7 @@
 27	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 497
+# parallel_id = hk/497
 # text = 即係唱完歌我就……嗰個係我嘅職業囖。
 1	即係	即係	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	唱	唱	VERB	_	_	0	root	_	SpaceAfter=No
@@ -6125,6 +6622,7 @@
 14	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 498
+# parallel_id = hk/498
 # text = 跟住我哋係攞……
 1	跟住	跟住	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	我哋	我哋	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -6133,6 +6631,7 @@
 5	……	……	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 499
+# parallel_id = hk/499
 # text = 每一個月出糧畀我。
 1	每	每	DET	_	_	4	det	_	SpaceAfter=No
 2	一	一	NUM	_	_	4	nummod	_	SpaceAfter=No
@@ -6144,6 +6643,7 @@
 8	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 500
+# parallel_id = hk/500
 # text = 噉我就會走-或者走去第二間場啦，或者跑場啦，嗰啲。
 1	噉	噉	ADV	_	_	8	discourse	_	SpaceAfter=No
 2	我	我	PRON	_	_	8	nsubj	_	SpaceAfter=No
@@ -6167,6 +6667,7 @@
 20	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 501
+# parallel_id = hk/501
 # text = 噉根本就唔識廟街個啲……又同客傾偈啦，飲酒啦，嗰啲啦。
 1	噉	噉	ADV	_	_	5	discourse	_	SpaceAfter=No
 2	根本	根本	ADV	_	_	5	advmod	_	SpaceAfter=No
@@ -6190,6 +6691,7 @@
 20	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 502
+# parallel_id = hk/502
 # text = 噉我當時個內心都覺得好唔開心呀，覺得好似好委屈自己。
 1	噉	噉	ADV	_	_	7	discourse	_	SpaceAfter=No
 2	我	我	PRON	_	_	7	nsubj	_	SpaceAfter=No
@@ -6211,6 +6713,7 @@
 18	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 503
+# parallel_id = hk/503
 # text = 跟住呢，漸漸我識咗嗰啲客呀。之後呢，我覺得嗰啲客呢，都-都覺得係-好似當我係朋友噉囖。
 1	跟住	跟住	ADV	_	_	6	advmod	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -6250,6 +6753,7 @@
 36	。	。	PUNCT	_	_	17	punct	_	SpaceAfter=No
 
 # sent_id = 504
+# parallel_id = hk/504
 # text = 噉我哋一齊去飲茶，一齊去食飯。
 1	噉	噉	ADV	_	_	4	discourse	_	SpaceAfter=No
 2	我哋	我哋	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -6263,6 +6767,7 @@
 10	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 505
+# parallel_id = hk/505
 # text = 甚至乎我請佢哋飲茶，請佢哋食飯。
 1	甚至乎	甚至乎	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -6276,6 +6781,7 @@
 10	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 506
+# parallel_id = hk/506
 # text = 噉佢哋返嚟又聽我唱歌，呀，打賞畀我。
 1	噉	噉	ADV	_	_	5	discourse	_	SpaceAfter=No
 2	佢哋	佢哋	PRON	_	_	5	nsubj	_	SpaceAfter=No
@@ -6293,6 +6799,7 @@
 14	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 507
+# parallel_id = hk/507
 # text = 因為我哋，係退休先嚟。
 1	因為	因為	ADV	_	_	7	advmod	_	SpaceAfter=No
 2	我哋	我哋	PRON	_	_	7	nsubj	_	SpaceAfter=No
@@ -6304,6 +6811,7 @@
 8	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 508
+# parallel_id = hk/508
 # text = 太悶，喺屋企，除非話阿彌陀佛對住部-四埲牆啫。
 1	太	太	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	悶	悶	ADJ	_	_	4	advcl	_	SpaceAfter=No
@@ -6325,6 +6833,7 @@
 18	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 509
+# parallel_id = hk/509
 # text = 夜總會係聽人唱，嚟嗰度係自己實踐去唱。
 1	夜總會	夜總會	NOUN	_	_	3	nsubj	_	SpaceAfter=No
 2	係	係	VERB	_	_	0	root	_	SpaceAfter=No
@@ -6342,6 +6851,7 @@
 14	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 510
+# parallel_id = hk/510
 # text = 感覺係唔同。
 1	感覺	感覺	NOUN	_	_	4	nsubj	_	SpaceAfter=No
 2	係	係	AUX	_	_	4	cop	_	SpaceAfter=No
@@ -6350,6 +6860,7 @@
 5	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 511
+# parallel_id = hk/511
 # text = 畀我一個困難呢，係歡樂。
 1	畀	畀	VERB	_	_	0	root	_	SpaceAfter=No
 2	我	我	PRON	_	_	1	iobj	_	SpaceAfter=No
@@ -6363,6 +6874,7 @@
 10	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 512
+# parallel_id = hk/512
 # text = 因為退休之年嘅話呢，除去食飯，同仔女有-冇-冇-冇-冇乜傾咖嘛！
 1	因為	因為	ADV	_	_	21	advmod	_	SpaceAfter=No
 2	退休	退休	VERB	_	_	4	acl	_	SpaceAfter=No
@@ -6391,6 +6903,7 @@
 25	！	！	PUNCT	_	_	21	punct	_	SpaceAfter=No
 
 # sent_id = 513
+# parallel_id = hk/513
 # text = 有乜傾呢，一味講，你返去自己問呀，你同你老豆老母有咩傾吖。
 1	有	有	VERB	_	_	0	root	_	SpaceAfter=No
 2	乜	乜	PRON	_	_	1	obj	_	SpaceAfter=No
@@ -6418,6 +6931,7 @@
 24	。	。	PUNCT	_	_	20	punct	_	SpaceAfter=No
 
 # sent_id = 514
+# parallel_id = hk/514
 # text = 傾唔兩句呀-呀-呀-呀，頂嘴㗎啦，啱唔啱先。
 1	傾	傾	VERB	_	_	13	advcl	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -6442,6 +6956,7 @@
 21	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No
 
 # sent_id = 515
+# parallel_id = hk/515
 # text = 出面嗰度識好多嗰啲朋友，聽下歌，開下心。
 1	出面	出面	NOUN	_	_	3	obl	_	SpaceAfter=No
 2	嗰度	嗰度	ADP	_	_	1	case:loc	_	SpaceAfter=No
@@ -6461,6 +6976,7 @@
 16	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 516
+# parallel_id = hk/516
 # text = 攰攰地返屋企沖個涼，搵下周公，呀～噉咪幾爽。
 1	攰攰地	攰攰地	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	返	返	VERB	_	_	0	root	_	SpaceAfter=No
@@ -6482,6 +6998,7 @@
 18	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 517
+# parallel_id = hk/517
 # text = 冇苛求，冇苛求呀。
 1	冇	冇	VERB	_	_	0	root	_	SpaceAfter=No
 2	苛求	苛求	NOUN	_	_	1	obj	_	SpaceAfter=No
@@ -6492,6 +7009,7 @@
 7	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 518
+# parallel_id = hk/518
 # text = 頭先又話夜總會嗰時呢，嗰時廟街係同而家有冇分別。
 1	頭先	頭先	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No
 2	又	又	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -6511,6 +7029,7 @@
 16	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 519
+# parallel_id = hk/519
 # text = 一樣，一樣，冇乜分別，差唔多。係呢三檔以前冇，而家有。
 1	一樣	一樣	ADJ	_	_	0	root	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -6534,6 +7053,7 @@
 20	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 520
+# parallel_id = hk/520
 # text = 一二三，呢三檔，以前冇呀。
 1	一	一	NUM	_	_	0	root	_	SpaceAfter=No
 2	二	二	NUM	_	_	1	conj	_	SpaceAfter=No
@@ -6549,6 +7069,7 @@
 12	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 521
+# parallel_id = hk/521
 # text = 呀，我對呢個唱歌好有興趣嘅。初初呢，就由唱歌而-而嚟嘅。噉後尾呢，唱唱下，中意做嘞。
 1	呀	呀	INTJ	_	_	9	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -6586,6 +7107,7 @@
 34	。	。	PUNCT	_	_	32	punct	_	SpaceAfter=No
 
 # sent_id = 522
+# parallel_id = hk/522
 # text = 噉就-噉有啲人退咗休就頂畀我，噉就頂嚟做囖。
 1	噉	噉	ADV	_	_	2	discourse	_	SpaceAfter=No
 2	就	就	ADV	_	_	5	reparandum	_	SpaceAfter=No
@@ -6611,6 +7133,7 @@
 22	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 523
+# parallel_id = hk/523
 # text = 我叫做李紅呀，個個人就叫我做紅姐囖。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	叫做	叫做	VERB	_	_	0	root	_	SpaceAfter=No
@@ -6628,6 +7151,7 @@
 14	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 524
+# parallel_id = hk/524
 # text = 因為呢，呢條街呢，就係日頭呢，就係誒，畀人行嘅，條路。
 1	因為	因為	ADV	_	_	10	advmod	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -6656,6 +7180,7 @@
 25	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 525
+# parallel_id = hk/525
 # text = 噉喺夜晚呢，即係隔籬左右呢，都係政府合署嘅。噉所以呢，冇乜人行街，噉就，好-好多人喺度開檔嘅。
 1	噉	噉	ADV	_	_	12	discourse	_	SpaceAfter=No
 2	喺	喺	ADP	_	_	3	case	_	SpaceAfter=No
@@ -6693,6 +7218,7 @@
 34	。	。	PUNCT	_	_	31	punct	_	SpaceAfter=No
 
 # sent_id = 526
+# parallel_id = hk/526
 # text = 誒，由七點半就做到十一點半。
 1	誒	誒	INTJ	_	_	6	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -6705,6 +7231,7 @@
 9	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 527
+# parallel_id = hk/527
 # text = 都有成三十年㗎喇。
 1	都	都	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	有	有	VERB	_	_	0	root	_	SpaceAfter=No
@@ -6716,6 +7243,7 @@
 8	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 528
+# parallel_id = hk/528
 # text = 嗯，三十年嚟，冇咩經驗囖，經驗呢，都係，誒，讚多過彈囖。
 1	嗯	嗯	INTJ	_	_	7	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -6743,6 +7271,7 @@
 24	。	。	PUNCT	_	_	15	punct	_	SpaceAfter=No
 
 # sent_id = 529
+# parallel_id = hk/529
 # text = 噉有啲人移民咗去外國呢，都返嚟講話：「阿紅姐，你千祈唔好執咗呢個檔呀，呢度係廟街嘅文化。」
 1	噉	噉	ADV	_	_	2	discourse	_	SpaceAfter=No
 2	有	有	VERB	_	_	0	root	_	SpaceAfter=No
@@ -6781,6 +7310,7 @@
 35	」	」	PUNCT	_	_	22	punct	_	SpaceAfter=No
 
 # sent_id = 530
+# parallel_id = hk/530
 # text = 即係佢唔想見到，誒，冇咗呢個檔口。噉就有啲特色喺度囖。
 1	即係	即係	ADV	_	_	5	advmod	_	SpaceAfter=No
 2	佢	佢	PRON	_	_	5	nsubj	_	SpaceAfter=No
@@ -6807,6 +7337,7 @@
 23	。	。	PUNCT	_	_	18	punct	_	SpaceAfter=No
 
 # sent_id = 531
+# parallel_id = hk/531
 # text = 誒，老一輩嗰啲呢，已經過咗身㗎呢，都去咗七七八八㗎喇。
 1	誒	誒	INTJ	_	_	8	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -6830,6 +7361,7 @@
 20	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 532
+# parallel_id = hk/532
 # text = 以前唔係㗎，圍到嗰個欄行滿晒㗎。
 1	以前	以前	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -6847,6 +7379,7 @@
 14	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 533
+# parallel_id = hk/533
 # text = 啲人呀，嗰陣時呢，八零年-年代呀、七零年代呀，用啲五百蚊紙摺架飛機飛埋嚟。好捨得畀錢㗎。
 1	啲	啲	NOUN	_	NounType=Clf	2	clf:det	_	SpaceAfter=No
 2	人	人	NOUN	_	_	22	nsubj	_	SpaceAfter=No
@@ -6884,6 +7417,7 @@
 34	。	。	PUNCT	_	_	30	punct	_	SpaceAfter=No
 
 # sent_id = 534
+# parallel_id = hk/534
 # text = 係呀，冇而家噉樣㗎，二十、二十㗎，冇㗎，呀，嗰陣時真係好闊佬㗎。
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -6912,6 +7446,7 @@
 25	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 535
+# parallel_id = hk/535
 # text = 噉嗰班人就係水上嘅，即係躉船呀，運輸嘅。
 1	噉	噉	ADV	_	_	7	discourse	_	SpaceAfter=No
 2	嗰	嗰	DET	_	_	4	det	_	SpaceAfter=No
@@ -6931,6 +7466,7 @@
 16	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 536
+# parallel_id = hk/536
 # text = 噉，噉嗰陣時黃、賭、毒，百花齊放吖嘛，最-最搵到錢嗰陣時。
 1	噉	噉	ADV	_	_	11	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -6955,6 +7491,7 @@
 21	。	。	PUNCT	_	_	17	punct	_	SpaceAfter=No
 
 # sent_id = 537
+# parallel_id = hk/537
 # text = 嗰陣時梅艷芳，e1e1，仲參加新秀，呀，歌-歌唱新秀，呀，都未紅。
 1	嗰陣時	嗰陣時	NOUN	_	_	8	obl:tmod	_	SpaceAfter=No
 2	梅艷芳	梅艷芳	PROPN	_	_	8	nsubj	_	SpaceAfter=No
@@ -6981,6 +7518,7 @@
 23	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 538
+# parallel_id = hk/538
 # text = 呀，你諗下。
 1	呀	呀	PART	_	_	4	discourse:sp	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -6990,6 +7528,7 @@
 6	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 539
+# parallel_id = hk/539
 # text = 梅艷芳喺度唱過，羅文喺度唱過，呀，尹光又喺度唱過。幾多明星喺度唱過呀。
 1	梅艷芳	梅艷芳	PROPN	_	_	3	nsubj	_	SpaceAfter=No
 2	喺度	喺度	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -7018,6 +7557,7 @@
 25	。	。	PUNCT	_	_	22	punct	_	SpaceAfter=No
 
 # sent_id = 540
+# parallel_id = hk/540
 # text = 喂，點呀？收未呀？
 1	喂	喂	INTJ	_	_	3	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -7030,6 +7570,7 @@
 9	？	？	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 541
+# parallel_id = hk/541
 # text = 我企喺度都，你哋都喺度唱。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	企	企	VERB	_	_	9	advcl	_	SpaceAfter=No
@@ -7043,6 +7584,7 @@
 10	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 542
+# parallel_id = hk/542
 # text = 呀，你企喺度，我哋都冇唱呀。
 1	呀	呀	INTJ	_	_	4	discourse:sp	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -7058,6 +7600,7 @@
 12	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 543
+# parallel_id = hk/543
 # text = 我哋，我哋走㗎喇，而家，而家落緊雨吖嘛。
 1	我哋	我哋	PRON	_	_	4	reparandum	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -7076,6 +7619,7 @@
 15	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 544
+# parallel_id = hk/544
 # text = 人不留人，就雨留人吖嘛！啱唔啱先。
 1	人	人	NOUN	_	_	3	nsubj	_	SpaceAfter=No
 2	不	不	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -7095,12 +7639,14 @@
 16	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No
 
 # sent_id = 545
+# parallel_id = hk/545
 # text = 冇辦法。
 1	冇	冇	VERB	_	_	0	root	_	SpaceAfter=No
 2	辦法	辦法	NOUN	_	_	1	obj	_	SpaceAfter=No
 3	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 546
+# parallel_id = hk/546
 # text = 因為呢，就，誒，我，即係話有啲人投訴啦，吓，噉誒，話噪音啦。噉所以我哋十一點半呢，即係，應該係十一點就要收㗎喇。
 1	因為	因為	ADV	_	_	12	advmod	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -7147,6 +7693,7 @@
 43	。	。	PUNCT	_	_	40	punct	_	SpaceAfter=No
 
 # sent_id = 547
+# parallel_id = hk/547
 # text = 噉有時延遲三個字嘅。
 1	噉	噉	ADV	_	_	3	discourse	_	SpaceAfter=No
 2	有時	有時	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -7158,6 +7705,7 @@
 8	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 548
+# parallel_id = hk/548
 # text = 屋企係咪呢個呢？
 1	屋企	屋企	NOUN	_	_	4	obl	_	SpaceAfter=No|Translit=uk1kei2|Gloss=home
 2	係咪	係	AUX	_	_	4	cop	_	SpaceAfter=No|Translit=hai6m4hai6|Gloss=COP-NEG-COP
@@ -7167,6 +7715,7 @@
 6	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 549
+# parallel_id = hk/549
 # text = 喂，阿Ｂ呀！
 1	喂	喂	INTJ	_	_	3	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -7175,6 +7724,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 550
+# parallel_id = hk/550
 # text = 你陪我去北極，睇北極星吖……
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	陪	陪	VERB	_	_	0	root	_	SpaceAfter=No
@@ -7188,6 +7738,7 @@
 10	……	……	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 551
+# parallel_id = hk/551
 # text = 睇北極光吖！
 1	睇	睇	VERB	_	_	0	root	_	SpaceAfter=No
 2	北極光	北極光	NOUN	_	_	1	obj	_	SpaceAfter=No
@@ -7195,6 +7746,7 @@
 4	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 552
+# parallel_id = hk/552
 # text = 好正㗎，坐郵輪㗎！
 1	好	好	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	正	正	ADJ	_	_	0	root	_	SpaceAfter=No
@@ -7206,6 +7758,7 @@
 8	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 553
+# parallel_id = hk/553
 # text = 你阿媽唔得閒呀。
 1	你	你	PRON	_	_	2	nmod	_	SpaceAfter=No
 2	阿媽	阿媽	NOUN	_	_	4	nsubj	_	SpaceAfter=No
@@ -7215,6 +7768,7 @@
 6	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 554
+# parallel_id = hk/554
 # text = 問咗你阿媽啦！
 1	問	問	VERB	_	_	0	root	_	SpaceAfter=No
 2	咗	咗	AUX	_	_	1	aux	_	SpaceAfter=No
@@ -7224,12 +7778,14 @@
 6	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 555
+# parallel_id = hk/555
 # text = 係呀！
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 556
+# parallel_id = hk/556
 # text = 你點解唔得閒陪我唧？
 1	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No
 2	點解	點解	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -7241,6 +7797,7 @@
 8	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 557
+# parallel_id = hk/557
 # text = 你去……你……放暑假㗎，唔使返學㗎！
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	去	去	VERB	_	_	0	root	_	SpaceAfter=No
@@ -7257,12 +7814,14 @@
 13	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 558
+# parallel_id = hk/558
 # text = 係呀！
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 559
+# parallel_id = hk/559
 # text = 四萬一……四萬幾蚊一個人㗎。
 1	四萬一	四萬一	NUM	_	_	3	reparandum	_	SpaceAfter=No
 2	……	……	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -7275,6 +7834,7 @@
 9	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 560
+# parallel_id = hk/560
 # text = 我唔使你出呀。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	唔使	唔使	VERB	_	_	0	root	_	SpaceAfter=No
@@ -7284,6 +7844,7 @@
 6	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 561
+# parallel_id = hk/561
 # text = 我請你去呀！
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	請	請	VERB	_	_	0	root	_	SpaceAfter=No
@@ -7293,6 +7854,7 @@
 6	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 562
+# parallel_id = hk/562
 # text = 你陪我啦！
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	陪	陪	VERB	_	_	0	root	_	SpaceAfter=No
@@ -7301,6 +7863,7 @@
 5	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 563
+# parallel_id = hk/563
 # text = 係呀，好正㗎，嗱。
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -7313,6 +7876,7 @@
 9	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 564
+# parallel_id = hk/564
 # text = 我哋坐郵輪喎，又可以呢……喺……喺……誒……上一上岸又可以去shopping喎。
 1	我哋	我哋	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	坐	坐	VERB	_	_	0	root	_	SpaceAfter=No
@@ -7339,6 +7903,7 @@
 23	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 565
+# parallel_id = hk/565
 # text = 嗱，我全程包晒你啦，
 1	嗱	嗱	INTJ	_	_	6	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -7352,6 +7917,7 @@
 10	，	，	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 566
+# parallel_id = hk/566
 # text = 嗱，包你啦……誒……誒……郵費、旅行費啦……誒……酒店費啦。
 1	嗱	嗱	INTJ	_	_	3	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -7375,6 +7941,7 @@
 20	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 567
+# parallel_id = hk/567
 # text = 四萬幾蚊一個人㗎！
 1	四萬幾	四萬幾	NUM	_	_	2	nummod	_	SpaceAfter=No
 2	蚊	緡	NOUN	_	NounType=Clf	0	root	_	SpaceAfter=No
@@ -7385,6 +7952,7 @@
 7	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 568
+# parallel_id = hk/568
 # text = 淨係坐郵輪嗰度都……
 1	淨係	淨係	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	坐	坐	VERB	_	_	0	root	_	SpaceAfter=No
@@ -7394,12 +7962,14 @@
 6	……	……	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 569
+# parallel_id = hk/569
 # text = 係呀！
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 570
+# parallel_id = hk/570
 # text = 點解你唔得閒唧！
 1	點解	點解	ADV	_	_	4	advmod	_	SpaceAfter=No
 2	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -7409,12 +7979,14 @@
 6	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 571
+# parallel_id = hk/571
 # text = 係呀！
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 572
+# parallel_id = hk/572
 # text = 你點解唔得閒唧！
 1	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No
 2	點解	點解	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -7424,6 +7996,7 @@
 6	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 573
+# parallel_id = hk/573
 # text = 阿爸、阿媽……唔得閒呀，
 1	阿爸	阿爸	NOUN	_	_	6	nsubj	_	SpaceAfter=No
 2	、	、	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -7435,6 +8008,7 @@
 8	，	，	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 574
+# parallel_id = hk/574
 # text = 佢哋要返工呀，
 1	佢哋	佢哋	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	要	要	AUX	_	_	3	aux	_	SpaceAfter=No
@@ -7443,6 +8017,7 @@
 5	，	，	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 575
+# parallel_id = hk/575
 # text = 唔係我唔使搵你啦！
 1	唔係	唔係	VERB	_	_	4	advcl	_	SpaceAfter=No
 2	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -7453,6 +8028,7 @@
 7	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 576
+# parallel_id = hk/576
 # text = 係呀，你陪我去啦！
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -7465,6 +8041,7 @@
 9	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 577
+# parallel_id = hk/577
 # text = 唔使你出呀，我請晒你呀！
 1	唔使	唔使	VERB	_	_	0	root	_	SpaceAfter=No
 2	你	你	PRON	_	_	1	obj	_	SpaceAfter=No
@@ -7479,6 +8056,7 @@
 11	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 578
+# parallel_id = hk/578
 # text = 我哋去見識下吖嘛。
 1	我哋	我哋	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	去	去	VERB	_	_	0	root	_	SpaceAfter=No
@@ -7488,6 +8066,7 @@
 6	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 579
+# parallel_id = hk/579
 # text = 未試過吖嘛。
 1	未	未	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	試	試	VERB	_	_	0	root	_	SpaceAfter=No
@@ -7496,6 +8075,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 580
+# parallel_id = hk/580
 # text = 坐郵輪去睇北極星！
 1	坐	坐	VERB	_	_	0	root	_	SpaceAfter=No
 2	郵輪	郵輪	NOUN	_	_	1	obj	_	SpaceAfter=No
@@ -7505,6 +8085,7 @@
 6	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 581
+# parallel_id = hk/581
 # text = 你放緊暑假㗎，你嗰陣時，唔使返學㗎！
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	放	放	VERB	_	_	0	root	_	SpaceAfter=No
@@ -7521,18 +8102,21 @@
 13	！	！	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 582
+# parallel_id = hk/582
 # text = 係褦！
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	褦	褦	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 583
+# parallel_id = hk/583
 # text = ＯＫ㗎！
 1	ＯＫ	ＯＫ	VERB	_	_	0	root	_	SpaceAfter=No
 2	㗎	㗎	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 584
+# parallel_id = hk/584
 # text = 我請你去！
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	請	請	VERB	_	_	0	root	_	SpaceAfter=No
@@ -7541,6 +8125,7 @@
 5	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 585
+# parallel_id = hk/585
 # text = 就噉決定啦！
 1	就	就	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	噉	噉	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -7549,6 +8134,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 586
+# parallel_id = hk/586
 # text = 你放緊暑假，唔使返學㗎！
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	放	放	VERB	_	_	0	root	_	SpaceAfter=No
@@ -7561,12 +8147,14 @@
 9	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 587
+# parallel_id = hk/587
 # text = 係呀！
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 588
+# parallel_id = hk/588
 # text = 冇問題，嗱，我請你呀！
 1	冇	冇	VERB	_	_	0	root	_	SpaceAfter=No
 2	問題	問題	NOUN	_	_	1	obj	_	SpaceAfter=No
@@ -7580,6 +8168,7 @@
 10	！	！	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 589
+# parallel_id = hk/589
 # text = 你去啦！
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	去	去	VERB	_	_	0	root	_	SpaceAfter=No
@@ -7587,6 +8176,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 590
+# parallel_id = hk/590
 # text = 你陪我咋嘛，有乜所謂唧？
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	陪	陪	VERB	_	_	0	root	_	SpaceAfter=No
@@ -7600,6 +8190,7 @@
 10	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 591
+# parallel_id = hk/591
 # text = 今日星期二喎！
 1	今日	今日	NOUN	_	_	2	obl:tmod	_	SpaceAfter=No
 2	星期二	星期二	NOUN	_	_	0	root	_	SpaceAfter=No
@@ -7607,6 +8198,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 592
+# parallel_id = hk/592
 # text = 今日星期三咩？
 1	今日	今日	NOUN	_	_	2	obl:tmod	_	SpaceAfter=No
 2	星期三	星期三	NOUN	_	_	0	root	_	SpaceAfter=No
@@ -7614,6 +8206,7 @@
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 593
+# parallel_id = hk/593
 # text = 今日星期四呀！
 1	今日	今日	NOUN	_	_	2	obl:tmod	_	SpaceAfter=No
 2	星期四	星期四	NOUN	_	_	0	root	_	SpaceAfter=No
@@ -7621,6 +8214,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 594
+# parallel_id = hk/594
 # text = 金剛郵輪九折喎！
 1	金剛郵輪	金剛郵輪	PROPN	_	_	3	nsubj	_	SpaceAfter=No
 2	九	九	NUM	_	_	3	nummod	_	SpaceAfter=No
@@ -7629,12 +8223,14 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 595
+# parallel_id = hk/595
 # text = 而家出發！
 1	而家	而家	NOUN	_	_	2	obl:tmod	_	SpaceAfter=No
 2	出發	出發	VERB	_	_	0	root	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 596
+# parallel_id = hk/596
 # text = 琴日呢，我返到屋企喎！
 1	琴日	琴日	NOUN	_	_	5	obl:tmod	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -7647,6 +8243,7 @@
 9	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 597
+# parallel_id = hk/597
 # text = 噉我收工返到屋企，跟住呢，我個仔問我喎：「你聽日去旅行呀？」
 1	噉	噉	ADV	_	_	3	discourse	_	SpaceAfter=No
 2	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -7675,6 +8272,7 @@
 25	」	」	PUNCT	_	_	21	punct	_	SpaceAfter=No
 
 # sent_id = 598
+# parallel_id = hk/598
 # text = 我話：「係吖！」
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	話	話	VERB	_	_	0	root	_	SpaceAfter=No
@@ -7686,6 +8284,7 @@
 8	」	」	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 599
+# parallel_id = hk/599
 # text = 噉你幾時返呀？
 1	噉	噉	ADV	_	_	4	discourse	_	SpaceAfter=No
 2	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -7695,6 +8294,7 @@
 6	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 600
+# parallel_id = hk/600
 # text = 我唔知㗎。
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -7703,6 +8303,7 @@
 5	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 601
+# parallel_id = hk/601
 # text = 總之我聽晚唔返啦～
 1	總之	總之	ADV	_	_	5	advmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	5	nsubj	_	SpaceAfter=No
@@ -7713,6 +8314,7 @@
 7	～	～	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 602
+# parallel_id = hk/602
 # text = 噉佢話：「你幾時會返嚟呀？」
 1	噉	噉	ADV	_	_	3	discourse	_	SpaceAfter=No
 2	佢	佢	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -7728,6 +8330,7 @@
 12	」	」	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 603
+# parallel_id = hk/603
 # text = 我唔知㗎。
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -7736,6 +8339,7 @@
 5	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 604
+# parallel_id = hk/604
 # text = 我聽晚會……唔返嚟。
 1	我	我	PRON	_	_	6	nsubj	_	SpaceAfter=No
 2	聽晚	聽晚	NOUN	_	_	6	obl:tmod	_	SpaceAfter=No
@@ -7746,6 +8350,7 @@
 7	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 605
+# parallel_id = hk/605
 # text = 跟住幾時返我就唔知㗎。
 1	跟住	跟住	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	幾時	幾時	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No
@@ -7758,6 +8363,7 @@
 9	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 606
+# parallel_id = hk/606
 # text = 總之就聽晚就唔返啦～」
 1	總之	總之	ADV	_	_	6	advmod	_	SpaceAfter=No
 2	就	就	ADV	_	_	6	advmod	_	SpaceAfter=No
@@ -7770,12 +8376,14 @@
 9	」	」	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 607
+# parallel_id = hk/607
 # text = 做咩呀？
 1	做咩	做咩	VERB	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 608
+# parallel_id = hk/608
 # text = 做咩噉問呀？
 1	做咩	做咩	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	噉	噉	ADV	_	_	3	discourse	_	SpaceAfter=No
@@ -7784,6 +8392,7 @@
 5	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 609
+# parallel_id = hk/609
 # text = 冇，我掛住你啫。
 1	冇	冇	VERB	_	_	0	root	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -7794,6 +8403,7 @@
 7	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 610
+# parallel_id = hk/610
 # text = 可能會掛住你啫
 1	可能	可能	AUX	_	_	3	aux	_	SpaceAfter=No
 2	會	會	AUX	_	_	3	aux	_	SpaceAfter=No
@@ -7802,12 +8412,14 @@
 5	啫	啫	PART	_	_	3	discourse:sp	_	SpaceAfter=No
 
 # sent_id = 611
+# parallel_id = hk/611
 # text = 噉𢰸！
 1	噉	噉	ADV	_	_	0	root	_	SpaceAfter=No
 2	𢰸	𢰸	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 612
+# parallel_id = hk/612
 # text = 成日都喺度……成日爆㗎，佢！
 1	成日	成日	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	都	都	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -7821,6 +8433,7 @@
 10	！	！	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 613
+# parallel_id = hk/613
 # text = 血壓高囖！
 1	血壓	血壓	NOUN	_	_	2	nsubj	_	SpaceAfter=No
 2	高	高	ADJ	_	_	0	root	_	SpaceAfter=No
@@ -7828,6 +8441,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 614
+# parallel_id = hk/614
 # text = 哎吔，係呀？
 1	哎吔	哎吔	INTJ	_	_	3	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -7836,6 +8450,7 @@
 5	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 615
+# parallel_id = hk/615
 # text = 係呀，有冇量過血壓呀？
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -7849,6 +8464,7 @@
 10	？	？	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 616
+# parallel_id = hk/616
 # text = 唱得幾好㗎！
 1	唱	唱	VERB	_	_	0	root	_	SpaceAfter=No
 2	得	得	PART	_	_	1	compound:ext	_	SpaceAfter=No
@@ -7858,6 +8474,7 @@
 6	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 617
+# parallel_id = hk/617
 # text = 係呀，唔錯呀！
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -7867,6 +8484,7 @@
 6	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 618
+# parallel_id = hk/618
 # text = 騎馬舞嚟㗎喎，呢個！
 1	騎馬舞	騎馬舞	NOUN	_	_	0	root	_	SpaceAfter=No
 2	嚟	唻	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -7878,6 +8496,7 @@
 8	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 619
+# parallel_id = hk/619
 # text = 唔識呀，真係！
 1	唔	唔	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	識	識	VERB	_	_	0	root	_	SpaceAfter=No
@@ -7887,6 +8506,7 @@
 6	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 620
+# parallel_id = hk/620
 # text = 太新啲歌。
 1	太	太	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	新	新	ADJ	_	_	0	root	_	SpaceAfter=No
@@ -7895,6 +8515,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 621
+# parallel_id = hk/621
 # text = 我唔係呢個年代。
 1	我	我	PRON	_	_	6	nsubj	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	6	advmod	_	SpaceAfter=No
@@ -7905,6 +8526,7 @@
 7	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 622
+# parallel_id = hk/622
 # text = 我唔係呢個年代！
 1	我	我	PRON	_	_	6	nsubj	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	6	advmod	_	SpaceAfter=No
@@ -7915,6 +8537,7 @@
 7	！	！	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 623
+# parallel_id = hk/623
 # text = 噉邊個玩音樂呀？
 1	噉	噉	ADV	_	_	3	discourse	_	SpaceAfter=No
 2	邊個	邊個	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -7924,12 +8547,14 @@
 6	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 624
+# parallel_id = hk/624
 # text = 卡拉ＯＫ呀？
 1	卡拉ＯＫ	卡拉ＯＫ	NOUN	_	_	0	root	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 625
+# parallel_id = hk/625
 # text = 玩得開心就得㗎啦……
 1	玩	玩	VERB	_	_	5	advcl	_	SpaceAfter=No
 2	得	得	PART	_	_	1	compound:ext	_	SpaceAfter=No
@@ -7941,6 +8566,7 @@
 8	……	……	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 626
+# parallel_id = hk/626
 # text = 繼續玩啦……繼續玩啦！
 1	繼續	繼續	VERB	_	_	0	root	_	SpaceAfter=No
 2	玩	玩	VERB	_	_	1	xcomp	_	SpaceAfter=No
@@ -7952,6 +8578,7 @@
 8	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 627
+# parallel_id = hk/627
 # text = 不如睇下鄭多變教嘅蟹蟹瘦身操先啦！
 1	不如	不如	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	睇	睇	VERB	_	_	0	root	_	SpaceAfter=No
@@ -7965,6 +8592,7 @@
 10	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 628
+# parallel_id = hk/628
 # text = 你要繳付四千二百六十蚊兩毫四仙。
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	要	要	AUX	_	_	3	aux	_	SpaceAfter=No
@@ -7978,6 +8606,7 @@
 10	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 629
+# parallel_id = hk/629
 # text = 四四方方嗰個呀，細啲呀！
 1	四四方方	四四方方	ADJ	_	_	3	amod	_	SpaceAfter=No
 2	嗰	嗰	DET	_	_	3	det	_	SpaceAfter=No
@@ -7990,6 +8619,7 @@
 9	！	！	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 630
+# parallel_id = hk/630
 # text = 三十乘三十啦？
 1	三十	三十	NUM	_	_	3	nsubj	_	SpaceAfter=No
 2	乘	乘	VERB	_	_	0	root	_	SpaceAfter=No
@@ -7998,12 +8628,14 @@
 5	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 631
+# parallel_id = hk/631
 # text = 係囖！
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	囖	囖	PART	_	_	1	discourse:sp	_	SpaceAfter=No
 3	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 632
+# parallel_id = hk/632
 # text = 嗰個呢？
 1	嗰	嗰	DET	_	_	2	det	_	SpaceAfter=No
 2	個	個	NOUN	_	NounType=Clf	0	root	_	SpaceAfter=No
@@ -8011,6 +8643,7 @@
 4	？	？	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 633
+# parallel_id = hk/633
 # text = 嗰個囖！
 1	嗰	嗰	DET	_	_	2	det	_	SpaceAfter=No
 2	個	個	NOUN	_	NounType=Clf	0	root	_	SpaceAfter=No
@@ -8018,6 +8651,7 @@
 4	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 634
+# parallel_id = hk/634
 # text = 都嗌你度好個尺寸。
 1	都	都	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	嗌	嗌	VERB	_	_	0	root	_	SpaceAfter=No
@@ -8029,6 +8663,7 @@
 8	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 635
+# parallel_id = hk/635
 # text = 唏～噉樣？
 1	唏	唏	INTJ	_	_	3	discourse	_	SpaceAfter=No
 2	～	～	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -8036,6 +8671,7 @@
 4	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 636
+# parallel_id = hk/636
 # text = 係囖，呢個好啲喎，呢個呀！
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	囖	囖	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -8052,6 +8688,7 @@
 13	！	！	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 637
+# parallel_id = hk/637
 # text = 唔好咁近個電視機呀！
 1	唔好	唔好	AUX	_	_	3	aux	_	SpaceAfter=No
 2	咁	咁	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -8062,6 +8699,7 @@
 7	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 638
+# parallel_id = hk/638
 # text = 因住整爛呀！
 1	因住	因住	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	整	整	VERB	_	_	0	root	_	SpaceAfter=No
@@ -8070,6 +8708,7 @@
 5	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 639
+# parallel_id = hk/639
 # text = Philip Wong……又食咁多嘢……
 1	Philip	Philip	PROPN	_	_	5	nsubj	_	_
 2	Wong	Wong	PROPN	_	_	1	flat	_	SpaceAfter=No
@@ -8082,6 +8721,7 @@
 9	……	……	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 640
+# parallel_id = hk/640
 # text = 肥死你呀！又食咁多嘢！
 1	肥	肥	VERB	_	_	0	root	_	SpaceAfter=No
 2	死	死	VERB	_	_	1	compound:vv	_	SpaceAfter=No
@@ -8096,6 +8736,7 @@
 11	！	！	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 641
+# parallel_id = hk/641
 # text = 下一站係天富，Next-stop-is-Tin-Fu。
 1	下	下	DET	_	_	3	det	_	SpaceAfter=No
 2	一	一	NUM	_	_	3	nummod	_	SpaceAfter=No
@@ -8107,6 +8748,7 @@
 8	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 642
+# parallel_id = hk/642
 # text = 媽、爸，八日七夜吉隆坡加浮羅交怡之旅嚟到第四日。
 1	媽	媽	NOUN	_	_	14	vocative	_	SpaceAfter=No
 2	、	、	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -8128,6 +8770,7 @@
 18	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No
 
 # sent_id = 643
+# parallel_id = hk/643
 # text = 住喺呢間酒店真係好正。
 1	住	住	VERB	_	_	8	csubj	_	SpaceAfter=No
 2	喺	喺	ADP	_	_	5	case	_	SpaceAfter=No
@@ -8140,6 +8783,7 @@
 9	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 644
+# parallel_id = hk/644
 # text = 一行出去就係泳池，再行出啲就係沙灘。
 1	一	一	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	行	行	VERB	_	_	6	advcl	_	SpaceAfter=No
@@ -8158,6 +8802,7 @@
 15	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 645
+# parallel_id = hk/645
 # text = 又曬黑返嚟喇，哈哈……
 1	又	又	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	曬	曬	VERB	_	_	0	root	_	SpaceAfter=No
@@ -8169,6 +8814,7 @@
 8	……	……	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 646
+# parallel_id = hk/646
 # text = 有冇掛住我呢？
 1	有	有	AUX	_	_	3	aux	_	SpaceAfter=No
 2	冇	冇	AUX	_	_	1	conj	_	SpaceAfter=No
@@ -8178,6 +8824,7 @@
 6	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 647
+# parallel_id = hk/647
 # text = 好快返嚟。
 1	好	好	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	快	快	ADJ	_	_	3	advmod	_	SpaceAfter=No
@@ -8185,6 +8832,7 @@
 4	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 648
+# parallel_id = hk/648
 # text = 秋，一四年五月二十二號。
 1	秋	秋	PROPN	_	_	0	root	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -8194,6 +8842,7 @@
 6	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 649
+# parallel_id = hk/649
 # text = 喂，明信片呀！
 1	喂	喂	INTJ	_	_	3	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -8202,6 +8851,7 @@
 5	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 650
+# parallel_id = hk/650
 # text = 愾，都返咗嚟喇！
 1	愾	愾	INTJ	_	_	4	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -8213,6 +8863,7 @@
 8	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 651
+# parallel_id = hk/651
 # text = 議員，各位議員，各位議員同事呢，剛才秘書處已經係作咗個嘅宣佈，五分鐘之後呢，就係，復會嘅。
 1	議員	議員	NOUN	_	_	14	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -8247,6 +8898,7 @@
 31	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No
 
 # sent_id = 652
+# parallel_id = hk/652
 # text = 噉呢，而家就過咗五分鐘時間。
 1	噉	噉	ADV	_	_	6	discourse	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -8261,6 +8913,7 @@
 11	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 653
+# parallel_id = hk/653
 # text = 噉，我就想同大家講講，其實今日呢，整個嘅會議過程呢，係分開幾部份㗎。
 1	噉	噉	VERB	_	_	8	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	8	punct	_	SpaceAfter=No
@@ -8289,6 +8942,7 @@
 25	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 654
+# parallel_id = hk/654
 # text = 而第一部份呢，就係剛才大家已經經歷過嘞，就係宣誓嘅過程。
 1	而	而	CCONJ	_	_	7	advmod	_	SpaceAfter=No
 2	第一	第一	ADJ	_	_	3	amod	_	SpaceAfter=No
@@ -8312,6 +8966,7 @@
 20	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 655
+# parallel_id = hk/655
 # text = 噉，而第二部份呢，就應該係，依一個嘅-進行我哋，議會嘅主席嘅選舉。
 1	噉	噉	ADV	_	_	10	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -8340,6 +8995,7 @@
 25	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 656
+# parallel_id = hk/656
 # text = 噉呢，但係不過呢，我知道亦都明白到有同事呢，對於我哋嘅候選人-我哋嘅主席嘅候選人呢，嘅國籍問題呢，有啲嘅意見。
 1	噉	噉	ADV	_	_	9	discourse	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -8382,6 +9038,7 @@
 39	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 657
+# parallel_id = hk/657
 # text = 或者有啲嘅地方需要澄清。
 1	或者	或者	CCONJ	_	_	2	advmod	_	SpaceAfter=No
 2	有	有	VERB	_	_	0	root	_	SpaceAfter=No
@@ -8393,6 +9050,7 @@
 8	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 658
+# parallel_id = hk/658
 # text = 噉，由於呢，我哋今日依一個嘅會議呢，係冇任何嘅程序或者規矩呢，係容許我哋喺依個議會場裏便呢，係進行澄清提問、辯論或者係提問嘅……諮詢等等嘅，所以因此呢，喺依個會議室裏便，我係唔可以係做依個工作。
 1	噉	噉	ADV	_	_	15	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -8461,6 +9119,7 @@
 65	。	。	PUNCT	_	_	58	punct	_	SpaceAfter=No
 
 # sent_id = 659
+# parallel_id = hk/659
 # text = 噉，但係不過，要係讓大家一啲關心嘅議員呢，能夠得到澄清嘅話呢，我就建議，阿梁君彥議員呢，喺稍後即刻嘅時間呢，就到到出便嗰度，就向新聞傳媒交待佢嘅國籍問題。
 1	噉	噉	ADV	_	_	24	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -8517,6 +9176,7 @@
 53	。	。	PUNCT	_	_	24	punct	_	SpaceAfter=No
 
 # sent_id = 660
+# parallel_id = hk/660
 # text = 而關心嘅議員同事呢，亦都可以出出面嗰度去聽聽，究竟佢嗰個情況點樣樣，同埋可以向佢提問。
 1	而	而	CCONJ	_	_	11	advmod	_	SpaceAfter=No
 2	關心	關心	VERB	_	_	5	acl	_	SpaceAfter=No
@@ -8549,6 +9209,7 @@
 29	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 661
+# parallel_id = hk/661
 # text = 就，議會裏便呢，我就唔能夠根據依一個嘅《議事規則》裏便呢，係容許大家提問，或者係作出任何嘅討論嘅。
 1	就	就	ADV	_	_	23	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -8587,6 +9248,7 @@
 35	。	。	PUNCT	_	_	23	punct	_	SpaceAfter=No
 
 # sent_id = 662
+# parallel_id = hk/662
 # text = 噉，我而家呢，依個時間呢，就讓大家呢，就出出去出便嗰度呢-誒……如果關心嘅同事吓，就喺出便去聽下梁君彥議員佢作出交待。
 1	噉	噉	ADV	_	_	12	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -8632,6 +9294,7 @@
 42	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No
 
 # sent_id = 663
+# parallel_id = hk/663
 # text = 噉，我期望呢，我哋嘅會議呢，將會係喺兩點半呢，係正式再復會嘅。
 1	噉	噉	ADV	_	_	4	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -8661,6 +9324,7 @@
 26	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 664
+# parallel_id = hk/664
 # text = 噉，我而家係宣佈係咁多。
 1	噉	噉	ADV	_	_	5	advmod	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -8674,6 +9338,7 @@
 10	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 665
+# parallel_id = hk/665
 # text = 噉呢，而家係進行休會。
 1	噉	噉	ADV	_	_	6	advmod	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -8685,6 +9350,7 @@
 8	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 666
+# parallel_id = hk/666
 # text = 議員，噉，而家呢，時間就都係兩點三十五分啦，比我原先係宣佈呢，係兩點三十分呢，復會時間已經遲咗五分鐘。
 1	議員	議員	NOUN	_	_	13	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -8727,6 +9393,7 @@
 39	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No
 
 # sent_id = 667
+# parallel_id = hk/667
 # text = 噉，由於時間-我唔想再延遲落去喇。
 1	噉	噉	ADV	_	_	10	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -8743,6 +9410,7 @@
 13	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 668
+# parallel_id = hk/668
 # text = 噉，我依家係正式復會。
 1	噉	噉	VERB	_	_	5	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -8754,6 +9422,7 @@
 8	。	。	VERB	_	_	5	obj	_	SpaceAfter=No
 
 # sent_id = 669
+# parallel_id = hk/669
 # text = 嗱，復會嘅時間呢，我當然-我期望呢，所有同事係坐返自己原來嘅位置。
 1	嗱	嗱	INTJ	_	_	12	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -8781,6 +9450,7 @@
 24	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No
 
 # sent_id = 670
+# parallel_id = hk/670
 # text = 噉呢，然後讓我哋可以喺一個嘅有秩序底下裏便呢，進行我哋今日嘅主席嗰個嘅投票嘅過程㗎。
 1	噉	噉	ADV	_	_	5	discourse	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -8813,6 +9483,7 @@
 29	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 671
+# parallel_id = hk/671
 # text = 噉呀，而家再請所有嘅同事呢，返返去自己原來嘅位置嗰度。
 1	噉	噉	ADV	_	_	6	discourse	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -8836,6 +9507,7 @@
 20	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 672
+# parallel_id = hk/672
 # text = 有議員想提出規程問題。
 1	有	有	VERB	_	_	0	root	_	SpaceAfter=No
 2	議員	議員	NOUN	_	_	1	obj	_	SpaceAfter=No
@@ -8846,6 +9518,7 @@
 7	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 673
+# parallel_id = hk/673
 # text = 好，好呢，就係可唔可以呢-其他同事呢，都係返返埋去自己個座位嗰度呢，讓我哋嘅秘書都可以係，即係幫手，幫我即係做一啲嘅文書嘅工作，得唔得呢？
 1	好	好	ADJ	_	_	0	root	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -8902,6 +9575,7 @@
 53	？	？	PUNCT	_	_	49	punct	_	SpaceAfter=No
 
 # sent_id = 674
+# parallel_id = hk/674
 # text = 因為如果唔係呢，我即係，即係如果冇咗呢一個嘅秘書幫我做，就困難啲嘅，不過都唔係唔可以。
 1	因為	因為	ADV	_	_	24	advmod	_	SpaceAfter=No
 2	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No
@@ -8939,6 +9613,7 @@
 34	。	。	PUNCT	_	_	24	punct	_	SpaceAfter=No
 
 # sent_id = 675
+# parallel_id = hk/675
 # text = 但不過我期望呢，就其他嘅議員同事可唔可以先返埋位度先，然後呢，就讓我哋可以進行呢一個嘅會議。
 1	但	但	CCONJ	_	_	4	cc	_	SpaceAfter=No
 2	不過	不過	CCONJ	_	_	4	cc	_	SpaceAfter=No
@@ -8977,6 +9652,7 @@
 35	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 676
+# parallel_id = hk/676
 # text = 噉，如果大家有任何規程問題呢，係可以提問嘅。
 1	噉	噉	ADV	_	_	11	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	11	punct	_	SpaceAfter=No
@@ -8995,6 +9671,7 @@
 15	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 677
+# parallel_id = hk/677
 # text = 噉，我可以畀大家時間。
 1	噉	噉	ADV	_	_	5	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	5	punct	_	SpaceAfter=No
@@ -9006,6 +9683,7 @@
 8	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 678
+# parallel_id = hk/678
 # text = 噉，主席，喂，呢個，我想問秘書處呢，佢有冇處理到梁君彥嘅國籍問題先？
 1	噉	噉	ADV	_	_	11	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -9034,12 +9712,14 @@
 25	？	？	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 679
+# parallel_id = hk/679
 # text = 佢正話……
 1	佢	佢	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	正話	正話	NOUN	_	_	0	root	_	SpaceAfter=No
 3	……	……	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 680
+# parallel_id = hk/680
 # text = 嗱，剛才呢，我講過呢，有關梁君彥議員嗰個國籍問題呢，就唔係今日我哋會議嘅裏面討論嘅範疇嘅。
 1	嗱	嗱	INTJ	_	_	7	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -9074,11 +9754,13 @@
 31	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 681
+# parallel_id = hk/681
 # text = 好。
 1	好	好	ADJ	_	_	0	root	_	SpaceAfter=No
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 682
+# parallel_id = hk/682
 # text = 等我講，得唔得？
 1	等	等	VERB	_	_	0	root	_	SpaceAfter=No
 2	我	我	PRON	_	_	1	obj	_	SpaceAfter=No
@@ -9090,6 +9772,7 @@
 8	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 683
+# parallel_id = hk/683
 # text = 噉呢，就因為呢，我剛才呢，已經係講咗，就係話，由於要讓大家進一步瞭解或者澄清有關梁君彥議員嗰個嘅國籍問題呢，我特別安排咗一個時間畀大家呢，喺出便同依個新聞傳媒嗰度呢，係作出交代同埋澄清嘅。
 1	噉	噉	ADV	_	_	13	discourse	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -9157,6 +9840,7 @@
 64	。	。	PUNCT	_	_	40	punct	_	SpaceAfter=No
 
 # sent_id = 684
+# parallel_id = hk/684
 # text = 噉，如果大家呢，如果剛才有出席到出便嗰個嘅，誒-嘅場合嘅話呢，其實大家可能都會知道究竟係嗰個情況點樣樣。
 1	噉	噉	ADV	_	_	28	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -9195,6 +9879,7 @@
 35	。	。	PUNCT	_	_	28	punct	_	SpaceAfter=No
 
 # sent_id = 685
+# parallel_id = hk/685
 # text = 不過呢，就係無論當事人呢，點樣澄清，點樣作出一個嘅解釋嘅話呢，其實我喺依個會議上高，我唔能夠作任何嘅保證大家滿意或者唔滿意嘅。
 1	不過	不過	CCONJ	_	_	5	advmod	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -9240,6 +9925,7 @@
 42	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 686
+# parallel_id = hk/686
 # text = 我作為一個會議嘅主持呢，我祇能夠係根據嗰個會議規則進行嗰個程序嘅唧。
 1	我	我	PRON	_	_	13	obl	_	SpaceAfter=No
 2	作為	作為	ADP	_	_	7	case	_	SpaceAfter=No
@@ -9266,6 +9952,7 @@
 23	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No
 
 # sent_id = 687
+# parallel_id = hk/687
 # text = 噉，如果大家想係確實要去去令到你嘅提問係得到滿意答覆嘅話呢，可以喺其他場合裏面呢，去處理。
 1	噉	噉	ADV	_	_	30	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -9301,6 +9988,7 @@
 32	。	。	PUNCT	_	_	30	punct	_	SpaceAfter=No
 
 # sent_id = 688
+# parallel_id = hk/688
 # text = 而今日我哋個會議裏面呢，係冇辦法去處理依個問題嘅。
 1	而	而	CCONJ	_	_	9	advmod	_	SpaceAfter=No
 2	今日	今日	NOUN	_	_	5	compound	_	SpaceAfter=No
@@ -9321,6 +10009,7 @@
 17	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 689
+# parallel_id = hk/689
 # text = 噉呀，而家呢，就想問問嘞，如果邊個-頭先邊個提，誒……有舉手話過提問嘅？
 1	噉	噉	ADV	_	_	9	discourse	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -9351,6 +10040,7 @@
 27	？	？	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 690
+# parallel_id = hk/690
 # text = 我睇唔倒呀。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	睇	睇	VERB	_	_	0	root	_	SpaceAfter=No
@@ -9360,6 +10050,7 @@
 6	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 691
+# parallel_id = hk/691
 # text = 我想秘書同我幫幫-俾個名單我，得唔得呀？
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	想	想	AUX	_	_	0	root	_	SpaceAfter=No
@@ -9380,6 +10071,7 @@
 17	？	？	PUNCT	_	_	13	punct	_	SpaceAfter=No
 
 # sent_id = 692
+# parallel_id = hk/692
 # text = 我睇唔倒。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	睇	睇	VERB	_	_	0	root	_	SpaceAfter=No
@@ -9388,6 +10080,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 693
+# parallel_id = hk/693
 # text = 嗱，誒……喺-喺今日呢，就即係我就唔想同大家爭論一啲嘅其他嘅問題，因為我呢，係冇一個權力呢，同大家去爭論任何嘅嘢嘅。
 1	嗱	嗱	INTJ	_	_	19	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -9437,6 +10130,7 @@
 46	。	。	PUNCT	_	_	19	punct	_	SpaceAfter=No
 
 # sent_id = 694
+# parallel_id = hk/694
 # text = 而家我祇係呢，係因為根據會議規則啦……
 1	而家	而家	NOUN	_	_	4	obl:tmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -9453,6 +10147,7 @@
 13	……	……	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 695
+# parallel_id = hk/695
 # text = 其實我都唔係好想主持依個會議嘅。
 1	其實	其實	ADV	_	_	5	advmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	5	nsubj	_	SpaceAfter=No
@@ -9468,6 +10163,7 @@
 12	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 696
+# parallel_id = hk/696
 # text = 不過呢，但係呢，但係不過呢，係會議規則呢，就話呢，誒……根據依個《議事規則》嘅呀……附表一，按照《議事規則》嘅附表一同埋六，第六同第七段嘅規定呢，係由我去做依個嘅會議嘅主持嘅。
 1	不過	不過	CCONJ	_	_	53	advmod	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -9535,6 +10231,7 @@
 64	。	。	PUNCT	_	_	53	punct	_	SpaceAfter=No
 
 # sent_id = 697
+# parallel_id = hk/697
 # text = 噉誒……而家呢，就我根據依個會議規則裏面呢，係祇能夠係主持依一個嘅投票依個過程嘅唧。
 1	噉	噉	ADV	_	_	16	discourse	_	SpaceAfter=No
 2	誒	誒	INTJ	_	_	16	discourse	_	SpaceAfter=No
@@ -9568,6 +10265,7 @@
 30	。	。	PUNCT	_	_	16	punct	_	SpaceAfter=No
 
 # sent_id = 698
+# parallel_id = hk/698
 # text = 噉呢，就其他嘢呢，我就冇辦法去處理嘅。
 1	噉	噉	ADV	_	_	11	discourse	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -9587,6 +10285,7 @@
 16	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 699
+# parallel_id = hk/699
 # text = 如果依家我去處理嘅話呢，我都違反咗依個會議規則。
 1	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No
 2	依家	依家	NOUN	_	_	4	obl:tmod	_	SpaceAfter=No
@@ -9606,6 +10305,7 @@
 16	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 700
+# parallel_id = hk/700
 # text = 依個亦都係唔合法嘅。
 1	依個	依個	PRON	_	_	6	nsubj	_	SpaceAfter=No
 2	亦	亦	ADV	_	_	6	advmod	_	SpaceAfter=No
@@ -9617,6 +10317,7 @@
 8	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 701
+# parallel_id = hk/701
 # text = 噉，所以大家呢，要我去表示究竟依個會係咪合法呢，我祇能夠根據會議規則呢，依個會而家進程係合法嘅。
 1	噉	噉	ADV	_	_	20	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -9653,6 +10354,7 @@
 33	。	。	PUNCT	_	_	20	punct	_	SpaceAfter=No
 
 # sent_id = 702
+# parallel_id = hk/702
 # text = 嗱，我再想請大家-大家議員同事呢，吓-就係如果有提問嘅話呢，我想希望大家係回咗你自己個座位裹面呢，係提問。
 1	嗱	嗱	INTJ	_	_	6	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -9696,6 +10398,7 @@
 40	。	。	PUNCT	_	_	25	punct	_	SpaceAfter=No
 
 # sent_id = 703
+# parallel_id = hk/703
 # text = 噉，我就會係，欸……邀請大家提出你個議程規程嘅內容出唻嘅。
 1	噉	噉	ADV	_	_	6	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -9720,6 +10423,7 @@
 21	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 704
+# parallel_id = hk/704
 # text = 我哋唔走呢？
 1	我哋	我哋	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -9728,6 +10432,7 @@
 5	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 705
+# parallel_id = hk/705
 # text = 你唔走，唔緊要。
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -9738,6 +10443,7 @@
 7	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 706
+# parallel_id = hk/706
 # text = 總之唔好騷擾倒我哋嘅話呢，我可以繼續嘅。
 1	總之	總之	ADV	_	_	11	advmod	_	SpaceAfter=No
 2	唔好	唔好	AUX	_	_	3	aux	_	SpaceAfter=No
@@ -9754,6 +10460,7 @@
 13	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 707
+# parallel_id = hk/707
 # text = 誒……好，而家呢，喺秘書畀我嘅名單裏便呢，第一位就係阿毛孟靜議員。
 1	誒	誒	INTJ	_	_	3	discourse	_	SpaceAfter=No
 2	……	……	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -9781,6 +10488,7 @@
 24	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 708
+# parallel_id = hk/708
 # text = 噉呢就，根據議事規則裏便唻講話呢，今日個規程問題呢，只能夠涉及到有關依個選舉個過程嘅情況嘅唧。
 1	噉	噉	ADV	_	_	22	discourse	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -9817,6 +10525,7 @@
 33	。	。	PUNCT	_	_	22	punct	_	SpaceAfter=No
 
 # sent_id = 709
+# parallel_id = hk/709
 # text = 噉就，希望如果其他問題嘅話呢，就希望你透過其他嘅場合裏面去發表你嘅意見-嘅提問。
 1	噉	噉	ADV	_	_	4	advmod	_	SpaceAfter=No
 2	就	就	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -9847,6 +10556,7 @@
 27	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 710
+# parallel_id = hk/710
 # text = 好嘑，而家請阿毛孟靜議員，唔該。
 1	好	好	ADJ	_	_	0	root	_	SpaceAfter=No
 2	嘑	嘑	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -9861,6 +10571,7 @@
 11	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 711
+# parallel_id = hk/711
 # text = 呀，好多謝阿主席。
 1	呀	呀	INTJ	_	_	4	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -9871,6 +10582,7 @@
 7	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 712
+# parallel_id = hk/712
 # text = 吓，我唔係故意要為難你或者要什麼。
 1	吓	吓	INTJ	_	_	5	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -9887,6 +10599,7 @@
 13	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 713
+# parallel_id = hk/713
 # text = 就好多謝你都話已經，就，意圖安排我哋出去聽阿梁君彥嘅解釋。
 1	就	就	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	好	好	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -9910,6 +10623,7 @@
 20	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 714
+# parallel_id = hk/714
 # text = 而解釋呢，都聽咗嘞。
 1	而	而	CCONJ	_	_	6	advmod	_	SpaceAfter=No
 2	解釋	解釋	NOUN	_	_	6	obj:periph	_	SpaceAfter=No
@@ -9922,6 +10636,7 @@
 9	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 715
+# parallel_id = hk/715
 # text = 就話第一封信有關佢個國籍、外國居留權嘅問題。
 1	就	就	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	話	話	VERB	_	_	0	root	_	SpaceAfter=No
@@ -9940,6 +10655,7 @@
 15	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 716
+# parallel_id = hk/716
 # text = 佢第一封信呢，就話enclose係，呀，已經附上，誒，嗰個，誒，放棄國籍嘅聲明。
 1	佢	佢	PRON	_	_	4	nmod	_	SpaceAfter=No
 2	第一	第一	ADJ	_	_	4	amod	_	SpaceAfter=No
@@ -9970,6 +10686,7 @@
 27	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 717
+# parallel_id = hk/717
 # text = 呀，嗰個copy呢，就原來不存在。
 1	呀	呀	INTJ	_	_	10	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -9984,6 +10701,7 @@
 11	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 718
+# parallel_id = hk/718
 # text = 因為係電郵。
 1	因為	因為	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	係	係	AUX	_	_	3	cop	_	SpaceAfter=No
@@ -9991,6 +10709,7 @@
 4	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 719
+# parallel_id = hk/719
 # text = 而第二封嗰個呢，先至係真嘅。
 1	而	而	CCONJ	_	_	9	advmod	_	SpaceAfter=No
 2	第二	第二	ADJ	_	_	3	amod	_	SpaceAfter=No
@@ -10005,6 +10724,7 @@
 11	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 720
+# parallel_id = hk/720
 # text = 就佢暫時未收到手，下馬？
 1	就	就	ADV	_	_	5	advmod	_	SpaceAfter=No
 2	佢	佢	PRON	_	_	5	nsubj	_	SpaceAfter=No
@@ -10018,6 +10738,7 @@
 10	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 721
+# parallel_id = hk/721
 # text = 噉，我就，呀，規程問題啦。
 1	噉	噉	ADV	_	_	9	advmod	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	9	punct	_	SpaceAfter=No
@@ -10032,6 +10753,7 @@
 11	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 722
+# parallel_id = hk/722
 # text = 因為基本法講到明呢，呀，大會主席就必須沒有外國居留權㗎。
 1	因為	因為	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	基本法	基本法	NOUN	_	_	3	nsubj	_	SpaceAfter=No
@@ -10053,6 +10775,7 @@
 18	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 723
+# parallel_id = hk/723
 # text = 噉，兩封，即使係政府發出嘅，信呢，就唔係一定係法律文件唻𠿪。
 1	噉	噉	ADV	_	_	17	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -10080,6 +10803,7 @@
 24	。	。	PUNCT	_	_	17	punct	_	SpaceAfter=No
 
 # sent_id = 724
+# parallel_id = hk/724
 # text = 我哋最緊要就係要嗰封，呀，放棄國籍聲明，呀，所謂係，呀，Declaration_of_Renunciation_of_UK_citizenship。
 1	我哋	我哋	PRON	_	_	5	nsubj	_	SpaceAfter=No
 2	最	最	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -10107,6 +10831,7 @@
 24	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 725
+# parallel_id = hk/725
 # text = 呢個，呀，因為我自己都有一份，吓。
 1	呢個	呢個	PRON	_	_	9	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -10124,6 +10849,7 @@
 14	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 726
+# parallel_id = hk/726
 # text = 我-我-我哋係咪應該要等埋佢有呢個噉樣嘅文件喺手。
 1	我	我	PRON	_	_	5	reparandum	_	SpaceAfter=No
 2	-	-	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -10146,6 +10872,7 @@
 19	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 727
+# parallel_id = hk/727
 # text = 咩都係正正式式嘞，我哋先開始呢個，誒，誒，選舉嘅程序呢？
 1	咩	咩	PRON	_	_	4	nsubj	_	SpaceAfter=No
 2	都	都	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -10169,6 +10896,7 @@
 20	？	？	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 728
+# parallel_id = hk/728
 # text = 好，誒，唔該你，誒，毛孟靜議員。
 1	好	好	ADJ	_	_	0	root	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -10184,6 +10912,7 @@
 12	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 729
+# parallel_id = hk/729
 # text = 頭先我都講過呢，就係有關你呢個提問呢，就係要祇能夠涉及到嗰個嘅選舉過程同埋-或-或者係同依個選舉有關嘅嘢啦。
 1	頭先	頭先	NOUN	_	_	4	obl:tmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -10227,6 +10956,7 @@
 40	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 730
+# parallel_id = hk/730
 # text = 噉，但係，剛才你想係，aam6，澄清阿梁君彥議員呢，嗰個，即係都係，國籍問題啦，下。
 1	噉	噉	ADV	_	_	8	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -10259,6 +10989,7 @@
 29	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 731
+# parallel_id = hk/731
 # text = 噉，但係不過問題在於就係，剛才我已經係特別安排咗一個嘅場合，就畀梁君彥議員呢，就向大家同埋向社會大眾呢，作出澄清同埋交代嘅。
 1	噉	噉	ADV	_	_	6	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -10303,6 +11034,7 @@
 41	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 732
+# parallel_id = hk/732
 # text = 噉呢，就對於佢能唔能夠達到你頭先提問嗰個嘅要求呢，我就唔能夠作出任何嘅意見。
 1	噉	噉	ADV	_	_	23	discourse	_	SpaceAfter=No
 2	呢	呢	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -10333,6 +11065,7 @@
 27	。	。	PUNCT	_	_	23	punct	_	SpaceAfter=No
 
 # sent_id = 733
+# parallel_id = hk/733
 # text = 不過我想同大家講講，就鑒於阿梁君彥議員呢，就已經一而再，再而三呢，除咗提供資料，同埋係公開場合裏面係澄清之後呢，噉，其實議員呀，可以自己自行去決定一下稍後時間會唔會去投票支持佢嘅。
 1	不過	不過	ADV	_	_	6	advmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	6	nsubj	_	SpaceAfter=No
@@ -10392,6 +11125,7 @@
 56	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 734
+# parallel_id = hk/734
 # text = 即係如果大家覺得阿梁君彥議員呢，或者未曾答倒你哋所提問嘅問題嘅話呢，噉，就變咗大家可以-可以呢……係去尋求……
 1	即係	即係	ADV	_	_	25	advmod	_	SpaceAfter=No
 2	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No
@@ -10431,6 +11165,7 @@
 36	……	……	PUNCT	_	_	25	punct	_	SpaceAfter=No
 
 # sent_id = 735
+# parallel_id = hk/735
 # text = 噉，梁天琦都唔使畀人disqualify啦，係咪呀？
 1	噉	噉	ADV	_	_	8	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -10447,6 +11182,7 @@
 13	？	？	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 736
+# parallel_id = hk/736
 # text = 我都唔知佢究竟係咪真係有合法嘅權利唻參選，你就叫我自己先考慮可唔可以投票畀佢，下馬？
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No
 2	都	都	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -10482,6 +11218,7 @@
 32	？	？	PUNCT	_	_	19	punct	_	SpaceAfter=No
 
 # sent_id = 737
+# parallel_id = hk/737
 # text = 你可唔可以叫選民自行……畀梁天琦吖？
 1	你	你	PRON	_	_	5	nsubj	_	SpaceAfter=No
 2	可	可以	AUX	_	_	5	aux	_	SpaceAfter=No
@@ -10497,6 +11234,7 @@
 12	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 738
+# parallel_id = hk/738
 # text = 嗱，因為呢，我哋依個立法會嘅主席嘅選舉呢，係按照依個《議事規則》嘅附表第一嘅程序進行嘅。
 1	嗱	嗱	INTJ	_	_	15	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -10529,6 +11267,7 @@
 29	。	。	PUNCT	_	_	15	punct	_	SpaceAfter=No
 
 # sent_id = 739
+# parallel_id = hk/739
 # text = 如果喺程序進行嘅條文，係容許議員呢，喺選舉主-主席嘅會議上高，就候選人嘅事進行討論。
 1	如果	如果	SCONJ	_	_	2	mark	_	SpaceAfter=No
 2	喺	喺	VERB	_	_	8	advcl	_	SpaceAfter=No
@@ -10560,6 +11299,7 @@
 28	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 740
+# parallel_id = hk/740
 # text = 而事實上呢，有關討論呢，已經喺琴日嘅論壇……
 1	而	而	CCONJ	_	_	10	advmod	_	SpaceAfter=No
 2	事實上	事實上	ADV	_	_	10	advmod	_	SpaceAfter=No
@@ -10577,6 +11317,7 @@
 14	……	……	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 741
+# parallel_id = hk/741
 # text = 主席呀，我唔係……我唔係要求討論呀。
 1	主席	主席	NOUN	_	_	6	vocative	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -10594,6 +11335,7 @@
 14	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 742
+# parallel_id = hk/742
 # text = 我係要求……呢啲係好清楚嘅法律上嘅澄清呀。
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	係	係	VERB	_	_	0	root	_	SpaceAfter=No
@@ -10612,6 +11354,7 @@
 15	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 743
+# parallel_id = hk/743
 # text = 佢一定要有一份噉樣嘅，呀，正正式式係放棄英國國籍嘅聲明嘅文件。
 1	佢	佢	PRON	_	_	4	nsubj	_	SpaceAfter=No
 2	一定	一定	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -10636,6 +11379,7 @@
 21	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 744
+# parallel_id = hk/744
 # text = 最好畀原裝我哋添啦。
 1	最好	最好	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	畀	畀	VERB	_	_	0	root	_	SpaceAfter=No
@@ -10646,6 +11390,7 @@
 7	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 745
+# parallel_id = hk/745
 # text = 噉，但係如果暫時冇原裝，即係呀，copy都有畀唻睇下。
 1	噉	噉	ADV	_	_	14	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -10668,6 +11413,7 @@
 19	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No
 
 # sent_id = 746
+# parallel_id = hk/746
 # text = 但係而家講得好清楚。
 1	但係	但係	CCONJ	_	_	3	advmod	_	SpaceAfter=No
 2	而家	而家	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No
@@ -10678,6 +11424,7 @@
 7	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 747
+# parallel_id = hk/747
 # text = 我嘅理解係佢未收倒呢份文件。
 1	我	我	PRON	_	_	3	nmod	_	SpaceAfter=No
 2	嘅	嘅	PART	_	_	1	case	_	SpaceAfter=No
@@ -10692,6 +11439,7 @@
 11	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 748
+# parallel_id = hk/748
 # text = 噉，我哋點可以喺呢度進行呢個選舉嘅過程呢？
 1	噉	噉	ADV	_	_	8	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	8	punct	_	SpaceAfter=No
@@ -10709,6 +11457,7 @@
 14	？	？	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 749
+# parallel_id = hk/749
 # text = em6……因為如果我自己瞭解呢，喺基本法裏面所講呀，個內容裏便呢，係講係候選，唔係，對唔住，係主席-主席-立法會嘅主席係唔能夠擁有任何其他國家嘅居留權依個問題。
 1	em6	em6	INTJ	_	_	7	discourse	_	SpaceAfter=No
 2	……	……	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -10763,6 +11512,7 @@
 51	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 750
+# parallel_id = hk/750
 # text = 係清楚寫咗喺度，就冇講到候選人嘅。
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	清楚	清楚	ADJ	_	_	3	advmod	_	SpaceAfter=No
@@ -10779,6 +11529,7 @@
 13	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 751
+# parallel_id = hk/751
 # text = 噉，我哋今日呢-我今日呢，就唔係同大家係辯論依啲問題，但係不過大家如果想去澄清有關依啲問題呢，就應該係透過其他途徑。
 1	噉	噉	ADV	_	_	13	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -10821,6 +11572,7 @@
 39	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No
 
 # sent_id = 752
+# parallel_id = hk/752
 # text = 而因為我，一來我唔係一個-即係法律嘅-嘅背景嘅一個嘅議員啦。
 1	而	而	CCONJ	_	_	8	advmod	_	SpaceAfter=No
 2	因為	因為	ADV	_	_	8	advmod	_	SpaceAfter=No
@@ -10846,6 +11598,7 @@
 22	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 753
+# parallel_id = hk/753
 # text = 而同時呢，我依個主席身份亦都唔能夠作任何嘅回答。
 1	而	而	CCONJ	_	_	12	advmod	_	SpaceAfter=No
 2	同時	同時	ADV	_	_	12	advmod	_	SpaceAfter=No
@@ -10865,6 +11618,7 @@
 16	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No
 
 # sent_id = 754
+# parallel_id = hk/754
 # text = 噉，我祇能夠呢……
 1	噉	噉	ADV	_	_	5	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -10875,6 +11629,7 @@
 7	……	……	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 755
+# parallel_id = hk/755
 # text = 唔好意思，我唔係特別要為難你，亦都，呀，覺得打直噉樣說話，打岔係，呀，唔禮貌嘅。
 1	唔好意思	唔好意思	INTJ	_	_	5	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -10906,12 +11661,14 @@
 28	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 756
+# parallel_id = hk/756
 # text = 唔緊要。
 1	唔	唔	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	緊要	緊要	ADJ	_	_	0	root	_	SpaceAfter=No
 3	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 757
+# parallel_id = hk/757
 # text = 但係你-正話你噉樣講呢，佢做咗主席呢，就不能夠有，呀，居留權。
 1	但係	但係	CCONJ	_	_	7	advmod	_	SpaceAfter=No
 2	你	你	PRON	_	_	5	reparandum	_	SpaceAfter=No
@@ -10939,6 +11696,7 @@
 24	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 758
+# parallel_id = hk/758
 # text = 喂，你如果係選嘅話，一陣半個鐘頭之內，十分鐘之內添，佢就已經係主席㗎嘞。
 1	喂	喂	INTJ	_	_	24	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -10968,6 +11726,7 @@
 26	。	。	PUNCT	_	_	24	punct	_	SpaceAfter=No
 
 # sent_id = 759
+# parallel_id = hk/759
 # text = 選完之後呀，有個人，吓，已經係主席，但佢仍然係未有-喺今日之內，未有我哋正話講嘅嗰份真真正正需要放棄國籍嘅聲明文件吖嘛！
 1	選	選	VERB	_	_	6	advcl	_	SpaceAfter=No
 2	完	完	VERB	_	_	1	compound:vv	_	SpaceAfter=No
@@ -11013,6 +11772,7 @@
 42	！	！	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 760
+# parallel_id = hk/760
 # text = 嗱，你係講得啱嘅！
 1	嗱	嗱	INTJ	_	_	4	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	4	punct	_	SpaceAfter=No
@@ -11025,11 +11785,13 @@
 9	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 761
+# parallel_id = hk/761
 # text = 多謝！
 1	多謝	多謝	VERB	_	_	0	root	_	SpaceAfter=No
 2	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 762
+# parallel_id = hk/762
 # text = 就係當佢如果係選咗之後呢，就即係如果係唔符合呢度呢，佢就唔應該成為一個嘅主席。
 1	就係	就係	ADV	_	_	24	advmod	_	SpaceAfter=No
 2	當	當	SCONJ	_	_	5	mark	_	SpaceAfter=No
@@ -11062,6 +11824,7 @@
 29	。	。	PUNCT	_	_	24	punct	_	SpaceAfter=No
 
 # sent_id = 763
+# parallel_id = hk/763
 # text = 依個係冇錯嘅。
 1	依個	依個	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	係	係	VERB	_	_	0	root	_	SpaceAfter=No
@@ -11070,6 +11833,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 764
+# parallel_id = hk/764
 # text = 但不過問題在於呢，我唔能夠作任何嘅一個-建議你，跟住點樣做，因為我冇依一個身份。
 1	但	但	ADV	_	_	4	cc	_	SpaceAfter=No
 2	不過	不過	CCONJ	_	_	4	cc	_	SpaceAfter=No
@@ -11103,6 +11867,7 @@
 30	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 765
+# parallel_id = hk/765
 # text = 我祇能夠係主持乜嘢呢……
 1	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No
 2	祇	祇	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -11114,6 +11879,7 @@
 8	……	……	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 766
+# parallel_id = hk/766
 # text = 主席，噉，你坐喺度做咩㗎？
 1	主席	主席	NOUN	_	_	8	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -11128,6 +11894,7 @@
 11	？	？	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 767
+# parallel_id = hk/767
 # text = 我主持一樣嘢，好簡單唧，即係，你講得啱呀。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	主持	主持	VERB	_	_	0	root	_	SpaceAfter=No
@@ -11149,6 +11916,7 @@
 18	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 768
+# parallel_id = hk/768
 # text = 我想澄清一下我主席做乜嘢喺度。
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	想	想	AUX	_	_	3	aux	_	SpaceAfter=No
@@ -11162,6 +11930,7 @@
 10	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 769
+# parallel_id = hk/769
 # text = 因為根據會議規則，我……祇係做兩樣嘢。
 1	因為	因為	ADV	_	_	9	advmod	_	SpaceAfter=No
 2	根據	根據	ADP	_	_	4	case	_	SpaceAfter=No
@@ -11179,6 +11948,7 @@
 14	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 770
+# parallel_id = hk/770
 # text = 我第一樣嘢呢，就係乜嘢呢，就係進行依一個嘅主席嘅選舉投票。
 1	我	我	PRON	_	_	4	nmod	_	SpaceAfter=No
 2	第一	第一	ADJ	_	_	4	amod	_	SpaceAfter=No
@@ -11205,6 +11975,7 @@
 23	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 771
+# parallel_id = hk/771
 # text = 而第二樣嘢呢，就係，宣布邊位嘅候選人呢，係當選。
 1	而	而	ADV	_	_	8	advmod	_	SpaceAfter=No
 2	第二	第二	ADJ	_	_	4	amod	_	SpaceAfter=No
@@ -11227,6 +11998,7 @@
 19	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 772
+# parallel_id = hk/772
 # text = 我祇係做兩樣嘢唧。
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	祇	祇	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -11239,6 +12011,7 @@
 9	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 773
+# parallel_id = hk/773
 # text = 其他嘢呢，我都唔應該做嘅。
 1	其他	其他	DET	_	_	2	det	_	SpaceAfter=No
 2	嘢	嘢	NOUN	_	_	9	obj:periph	_	SpaceAfter=No
@@ -11253,6 +12026,7 @@
 11	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 774
+# parallel_id = hk/774
 # text = 最後，一個規程問題。
 1	最後	最後	ADV	_	_	6	advmod	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	6	punct	_	SpaceAfter=No
@@ -11263,6 +12037,7 @@
 7	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 775
+# parallel_id = hk/775
 # text = 如果真係為咗抗爭，我係不同意而家呢一個噉樣嘅程序嘅，我都行出唻，我而家抗爭，企喺你後面，我係唔走。
 1	如果	如果	SCONJ	_	_	3	mark	_	SpaceAfter=No
 2	真	真	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -11304,6 +12079,7 @@
 38	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 776
+# parallel_id = hk/776
 # text = 你呼籲我走，我亦都唔走。
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	呼籲	呼籲	VERB	_	_	9	advcl	_	SpaceAfter=No
@@ -11317,6 +12093,7 @@
 10	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 777
+# parallel_id = hk/777
 # text = 係咪一路噉樣繼續落去嘅呢？
 1	係咪	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	一路	一路	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -11328,6 +12105,7 @@
 8	？	？	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 778
+# parallel_id = hk/778
 # text = 如果你係影響唔倒，誒，大家個投票個進程呢，我係唔阻，我-我-我係唔阻止你嘅。
 1	如果	如果	SCONJ	_	_	3	mark	_	SpaceAfter=No
 2	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -11363,6 +12141,7 @@
 32	。	。	PUNCT	_	_	27	punct	_	SpaceAfter=No
 
 # sent_id = 779
+# parallel_id = hk/779
 # text = 但係，你投票之前，首先必須要確定我、梁頌恆同埋姚松炎三位嘅投票權。
 1	但係	但係	ADV	_	_	10	advmod	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -11386,6 +12165,7 @@
 20	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 780
+# parallel_id = hk/780
 # text = 誒，嗱，其實我都冇權去確定㗎。
 1	誒	誒	INTJ	_	_	10	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -11402,6 +12182,7 @@
 13	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 781
+# parallel_id = hk/781
 # text = 確定你哋有冇權去投票呢，我祇能夠係接受秘書畀我嘅-嘅一個名單，包括咗候選人同埋有資格投票嘅議員。
 1	確定	確定	VERB	_	_	13	advcl	_	SpaceAfter=No
 2	你哋	你哋	PRON	_	_	6	nsubj	_	SpaceAfter=No
@@ -11439,6 +12220,7 @@
 34	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No
 
 # sent_id = 782
+# parallel_id = hk/782
 # text = 其實你應該係同返秘書處講，唔係同我講，因為我係冇權代佢-秘書處講依番說話㗎。
 1	其實	其實	ADV	_	_	4	advmod	_	SpaceAfter=No
 2	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -11472,6 +12254,7 @@
 30	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 783
+# parallel_id = hk/783
 # text = 如果你要講嘅話呢，你就由-你同依個秘書處嗰度-嗰度講。
 1	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No
 2	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -11495,6 +12278,7 @@
 20	。	。	PUNCT	_	_	19	punct	_	SpaceAfter=No
 
 # sent_id = 784
+# parallel_id = hk/784
 # text = 喔，第二位嘅就係許智峰議員。
 1	喔	喔	INTJ	_	_	8	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -11508,6 +12292,7 @@
 10	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 785
+# parallel_id = hk/785
 # text = 主席，我想你清醒啲諗一諗呢……
 1	主席	主席	NOUN	_	_	4	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -11521,6 +12306,7 @@
 10	……	……	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 786
+# parallel_id = hk/786
 # text = 誒，清唔清醒唔係你判斷㗎喎。
 1	誒	誒	INTJ	_	_	7	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -11535,6 +12321,7 @@
 11	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 787
+# parallel_id = hk/787
 # text = 我哋今日係咪應該再繼續，誒，落去會議，去選主席呢？
 1	我哋	我哋	PRON	_	_	6	nsubj	_	SpaceAfter=No
 2	今日	今日	NOUN	_	_	6	obl:tmod	_	SpaceAfter=No
@@ -11555,6 +12342,7 @@
 17	？	？	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 788
+# parallel_id = hk/788
 # text = 頭先毛孟靜議員同埋我哋好多非建制派議員已經講咗，我哋係唔信納梁君彥議員已經可以完全係脫離咗，係一個英籍，或者係脫離咗英國嘅居留權。
 1	頭先	頭先	NOUN	_	_	10	obl:tmod	_	SpaceAfter=No
 2	毛孟靜	毛孟靜	PROPN	_	_	10	nsubj	_	SpaceAfter=No
@@ -11596,6 +12384,7 @@
 38	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 789
+# parallel_id = hk/789
 # text = 噉，喺呢個情況底下，要我哋選舉係唔公道嘅。
 1	噉	噉	ADV	_	_	11	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -11614,6 +12403,7 @@
 15	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 790
+# parallel_id = hk/790
 # text = 呢個係第一。
 1	呢個	呢個	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	係	係	AUX	_	_	3	cop	_	SpaceAfter=No
@@ -11621,6 +12411,7 @@
 4	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 791
+# parallel_id = hk/791
 # text = 第二就係，正正你身後便嗰幾位議員，頭先我哋宣誓嘅時候，係遇到一啲，誒，障礙嘅。
 1	第二	第二	ADJ	_	_	3	nsubj	_	SpaceAfter=No
 2	就	就	ADV	_	_	19	advmod	_	SpaceAfter=No
@@ -11652,6 +12443,7 @@
 28	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 792
+# parallel_id = hk/792
 # text = 係監誓員秘書長呢，係冇處理到佢哋嘅宣誓。
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	監誓員	監誓員	NOUN	_	_	3	compound	_	SpaceAfter=No
@@ -11668,6 +12460,7 @@
 13	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 793
+# parallel_id = hk/793
 # text = 噉，所以秘書長亦都講咗佢哋陣間係喺個選主席嘅，誒，投票裏便，個選舉裏便，佢哋係唔可以投票嘅。
 1	噉	噉	ADV	_	_	6	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -11703,6 +12496,7 @@
 32	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 794
+# parallel_id = hk/794
 # text = 噉，但係我哋好多嘅議員都聽倒……似乎佢哋嗰種宣誓嘅方式，我哋過往歷屆嘅立法會議員都試過用類似嘅方式，都係冇問題嘅。
 1	噉	噉	ADV	_	_	35	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -11745,6 +12539,7 @@
 39	。	。	PUNCT	_	_	35	punct	_	SpaceAfter=No
 
 # sent_id = 795
+# parallel_id = hk/795
 # text = 噉證明我哋個宣誓嘅過程出咗問題。
 1	噉	噉	ADV	_	_	2	nsubj	_	SpaceAfter=No
 2	證明	證明	VERB	_	_	0	root	_	SpaceAfter=No
@@ -11759,6 +12554,7 @@
 11	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 796
+# parallel_id = hk/796
 # text = 令到我哋陣間投票，有幾個議員係冇辦法投票嘅話，呢個選舉係唔會係一個公平，符合程序公義嘅選舉唻嘅。
 1	令	令	VERB	_	_	5	advcl	_	SpaceAfter=No
 2	到	到	ADP	_	_	3	case	_	SpaceAfter=No
@@ -11796,6 +12592,7 @@
 34	。	。	PUNCT	_	_	19	punct	_	SpaceAfter=No
 
 # sent_id = 797
+# parallel_id = hk/797
 # text = 噉，我想邀請你再決定一下係唔係應該逆住咁多嘅程序公義去繼續處理呢個會議，去繼續選一個冇任何代表性嘅主席呢？
 1	噉	噉	ADV	_	_	5	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -11837,6 +12634,7 @@
 38	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 798
+# parallel_id = hk/798
 # text = 誒，主席，你作為，誒，代理主席呢，都係唔容易。
 1	誒	誒	INTJ	_	_	17	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -11858,6 +12656,7 @@
 18	。	。	PUNCT	_	_	17	punct	_	SpaceAfter=No
 
 # sent_id = 799
+# parallel_id = hk/799
 # text = 但係，我呢，支持你係執行《議事規則》，包括呢，維護議會嘅秩序，確保呢，我哋選主席嘅程序呢，能夠順利完成。
 1	但係	但係	ADV	_	_	6	advmod	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -11897,6 +12696,7 @@
 36	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 800
+# parallel_id = hk/800
 # text = 因為，呢個呢，係憲制嘅工作，亦都係全港市民呢，都係，誒，睇住我哋做嘅。
 1	因為	因為	ADV	_	_	9	advmod	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -11927,6 +12727,7 @@
 27	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 801
+# parallel_id = hk/801
 # text = 噉，其中，誒，《議事規則》，我相信-都請你瞭解一下。
 1	噉	噉	ADV	_	_	16	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -11950,6 +12751,7 @@
 20	。	。	PUNCT	_	_	16	punct	_	SpaceAfter=No
 
 # sent_id = 802
+# parallel_id = hk/802
 # text = 就係我哋有議員呢，係冇，呀，一個合理理由呢，就係圍住你嘅檯嘅後便啦。
 1	就	就	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	係	係	VERB	_	_	0	root	_	SpaceAfter=No
@@ -11982,6 +12784,7 @@
 29	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 803
+# parallel_id = hk/803
 # text = 我-我恐怕呢，就係有違反《議事規則》嘅-嘅嫌疑。
 1	我	我	PRON	_	_	3	reparandum	_	SpaceAfter=No
 2	-	-	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -12004,6 +12807,7 @@
 19	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 804
+# parallel_id = hk/804
 # text = 噉，我希望你-你都考慮下請呢啲議員回去。
 1	噉	噉	ADV	_	_	4	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -12022,6 +12826,7 @@
 15	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 805
+# parallel_id = hk/805
 # text = 如果佢哋，經過幾次嘅勸喻，都唔回去嘅話呢，喺維護議會秩序上呢，我就認為你應該執行《議事規則》。
 1	如果	如果	SCONJ	_	_	12	mark	_	SpaceAfter=No
 2	佢哋	佢哋	PRON	_	_	12	nsubj	_	SpaceAfter=No
@@ -12058,6 +12863,7 @@
 33	。	。	PUNCT	_	_	25	punct	_	SpaceAfter=No
 
 # sent_id = 806
+# parallel_id = hk/806
 # text = 呢個第一點。
 1	呢個	呢個	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	第一	第一	ADJ	_	_	3	amod	_	SpaceAfter=No
@@ -12065,6 +12871,7 @@
 4	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 807
+# parallel_id = hk/807
 # text = 第二點呢，就係關於個議員嘅投票權。
 1	第二	第二	ADJ	_	_	2	amod	_	SpaceAfter=No
 2	點	點	NOUN	_	NounType=Clf	6	nsubj	_	SpaceAfter=No
@@ -12080,6 +12887,7 @@
 12	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 808
+# parallel_id = hk/808
 # text = 誒，我同意你嘅判斷，就係，呀，秘書長呢，按照法例呢，係依法幫我哋監誓。
 1	誒	誒	INTJ	_	_	4	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -12109,6 +12917,7 @@
 26	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 809
+# parallel_id = hk/809
 # text = 呀，我認為呢，有幾位議員呢，佢係冇，呀，依照誓詞嘅內容呢，係完成宣誓。
 1	呀	呀	PART	_	_	4	discourse:sp	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -12140,6 +12949,7 @@
 28	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 810
+# parallel_id = hk/810
 # text = 噉所以呢，係選主席嘅過程裏便呢，其實係不能參與表決嘅。
 1	噉	噉	ADV	_	_	5	discourse	_	SpaceAfter=No
 2	所以	所以	ADV	_	_	5	advmod	_	SpaceAfter=No
@@ -12163,6 +12973,7 @@
 20	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 811
+# parallel_id = hk/811
 # text = 呢個不能參與表決嘅，誒，誒，情況呢，其實我相信所有議員都明白嘅。
 1	呢個	呢個	PRON	_	_	12	det	_	SpaceAfter=No
 2	不	不	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -12189,6 +13000,7 @@
 23	。	。	PUNCT	_	_	17	punct	_	SpaceAfter=No
 
 # sent_id = 812
+# parallel_id = hk/812
 # text = 如果不能夠完成宣誓……
 1	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No
 2	不	不	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -12198,6 +13010,7 @@
 6	……	……	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 813
+# parallel_id = hk/813
 # text = 而我嘅-亦都理解到呢，秘書長已經係畀多咗一次機會呢，所有，呀，佢有懷疑嘅議員呢，佢去再去宣誓嘞。
 1	而	而	ADV	_	_	6	advmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	6	nsubj	_	SpaceAfter=No
@@ -12239,6 +13052,7 @@
 38	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 814
+# parallel_id = hk/814
 # text = 我認為呢個呢，都係兼顧倒人情上嘅考慮。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	認為	認為	VERB	_	_	0	root	_	SpaceAfter=No
@@ -12256,6 +13070,7 @@
 14	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 815
+# parallel_id = hk/815
 # text = 噉，第三點，至於大家質疑梁君彥議員嗰個國籍問題，嗱，我就，誒，都係一早呢，都好關心呢件事，我多次同梁議員都澄清，誒，要求佢確認。
 1	噉	噉	ADV	_	_	23	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -12307,6 +13122,7 @@
 48	。	。	PUNCT	_	_	23	punct	_	SpaceAfter=No
 
 # sent_id = 816
+# parallel_id = hk/816
 # text = 佢多次呢，都係已經係好確認噉講呢，就係佢已經處理好。
 1	佢	佢	PRON	_	_	7	nsubj	_	SpaceAfter=No
 2	多	多	DET	_	_	7	advcl	_	SpaceAfter=No
@@ -12332,6 +13148,7 @@
 22	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 817
+# parallel_id = hk/817
 # text = 噉，及後呢，亦都將由英國領事館發出嘅兩封信，係畀大家去，誒，睇喇。
 1	噉	噉	ADV	_	_	17	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -12361,6 +13178,7 @@
 26	。	。	PUNCT	_	_	24	punct	_	SpaceAfter=No
 
 # sent_id = 818
+# parallel_id = hk/818
 # text = 噉，當然大家可以要，呀，一份，呀m，證書。
 1	噉	噉	ADV	_	_	6	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -12380,6 +13198,7 @@
 16	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 819
+# parallel_id = hk/819
 # text = 噉，呢個我理解嘅。
 1	噉	噉	ADV	_	_	5	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -12390,6 +13209,7 @@
 7	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 820
+# parallel_id = hk/820
 # text = 但係，起碼我自己睇咗嗰兩封信呢，我認為去到現在呢，冇其他新嘅證據呢，就話梁議員呢個英籍問題呢，係冇處理到嘅。
 1	但係	但係	ADV	_	_	6	advmod	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -12435,6 +13255,7 @@
 42	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 821
+# parallel_id = hk/821
 # text = 噉，喺-我哋既然今日定咗選舉主席呢，我認為我哋應該按照我哋，呀，定咗嘅呢一個，呀，時間安排呢，就係順利完成選主席。
 1	噉	噉	ADV	_	_	15	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -12480,6 +13301,7 @@
 42	。	。	PUNCT	_	_	15	punct	_	SpaceAfter=No
 
 # sent_id = 822
+# parallel_id = hk/822
 # text = 即係等如我哋其他選舉一樣，大家都明白，可能都會質疑唔同嘅候選人，佢，呀，某啲嘅聲明有誤。
 1	即係	即係	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	等如	等如	VERB	_	_	0	root	_	SpaceAfter=No
@@ -12512,6 +13334,7 @@
 29	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 823
+# parallel_id = hk/823
 # text = 噉，大家呢，就可以係日後透過唔同嘅方式去跟進，包括係，誒，司法覆核呀，或者其他法律程序。
 1	噉	噉	ADV	_	_	8	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -12546,6 +13369,7 @@
 31	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 824
+# parallel_id = hk/824
 # text = 我相信大家作為議員都好理解嘅。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	相信	相信	VERB	_	_	0	root	_	SpaceAfter=No
@@ -12559,6 +13383,7 @@
 10	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 825
+# parallel_id = hk/825
 # text = 噉，我希望，呀，阿梁議員你可以，呀，公平公正噉主持會議，確保我哋能夠順利選倒主席。
 1	噉	噉	ADV	_	_	4	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -12591,6 +13416,7 @@
 29	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 826
+# parallel_id = hk/826
 # text = 主席，我留意倒呢，我哋有啲同事可能對我哋兩位主席嘅候選人其中一位嘅資格，佢可能係提出咗有啲嘅意見，或者佢係覺得係有質疑嘅。
 1	主席	主席	NOUN	_	_	4	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -12638,6 +13464,7 @@
 44	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 827
+# parallel_id = hk/827
 # text = 不過我相信呢，即係喺呢個會議廳裏面呢，唔同政治立場嘅議員呢，佢哋對依件事係有唔同嘅態度，但係不能夠因為依一個原因呢，係阻礙我哋今天既定嘅議程。
 1	不過	不過	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -12692,6 +13519,7 @@
 51	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 828
+# parallel_id = hk/828
 # text = 由我哋，殊誒，完成依個宣誓嘅工作到到而家呢，我相信，即係，我哋已經係浪費咗兩個鐘頭嘅時間。
 1	由	由	ADP	_	_	12	mark	_	SpaceAfter=No
 2	我哋	我哋	PRON	_	_	7	nsubj	_	SpaceAfter=No
@@ -12727,6 +13555,7 @@
 32	。	。	PUNCT	_	_	18	punct	_	SpaceAfter=No
 
 # sent_id = 829
+# parallel_id = hk/829
 # text = 閣下嘅工作呢-閣下嘅工作呢，亦都係祇能夠主持今天呢個大主席嘅選舉，所以我希望你呢，唔好再浪費時間呢，而係能夠直接進入依個，欸，立法會主席選舉。
 1	閣下	閣下	PRON	_	_	3	nmod	_	SpaceAfter=No
 2	嘅	嘅	PART	_	_	1	case	_	SpaceAfter=No
@@ -12780,11 +13609,13 @@
 50	。	。	PUNCT	_	_	26	punct	_	SpaceAfter=No
 
 # sent_id = 830
+# parallel_id = hk/830
 # text = 唔該。
 1	唔該	唔該	VERB	_	_	0	root	_	SpaceAfter=No
 2	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 831
+# parallel_id = hk/831
 # text = 主席，誒，剛才毛孟靜議員已經提及到其中一個觀點呢，就係，我會用一個最嚴謹最，誒，謹慎合理嘅做法。
 1	主席	主席	NOUN	_	_	9	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -12823,6 +13654,7 @@
 35	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 832
+# parallel_id = hk/832
 # text = 就係我哋未見倒一份正式嘅文件之前呢，我哋好難去憑一個電郵又好，或者相關啲文件嘅副本呢，去到確認，哪怕我哋相信佢都好。
 1	就	就	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	係	係	VERB	_	_	0	root	_	SpaceAfter=No
@@ -12869,6 +13701,7 @@
 43	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 833
+# parallel_id = hk/833
 # text = 我覺得即係作為一個，誒-今次選主席啦，而依件事嘅後果呢，係可以好大嘅，可以帶嚟一個憲政嘅一個危機。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	覺得	覺得	VERB	_	_	12	reparandum	_	SpaceAfter=No
@@ -12912,6 +13745,7 @@
 40	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No
 
 # sent_id = 834
+# parallel_id = hk/834
 # text = 噉，我覺得，誒，係咪需要咁，誒，草率地，或者咁急速地，抱「必須要」噉樣處理呢？
 1	噉	噉	ADV	_	_	4	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -12945,6 +13779,7 @@
 30	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 835
+# parallel_id = hk/835
 # text = 噉，另一點，我覺得，誒-就住剛才有同事亦都有提問到嘅，就係國籍嘅取消同埋居留權嘅問題，我-我覺得喺-根據英國國籍法入便呢，其實當中仲有一啲嘅論點嘅爭議㗎。
 1	噉	噉	ADV	_	_	8	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -13002,6 +13837,7 @@
 54	。	。	PUNCT	_	_	35	punct	_	SpaceAfter=No
 
 # sent_id = 836
+# parallel_id = hk/836
 # text = 似乎我哋呢度未諮詢夠足夠嘅法律意見。
 1	似乎	似乎	ADV	_	_	5	advmod	_	SpaceAfter=No
 2	我哋	我哋	PRON	_	_	5	nsubj	_	SpaceAfter=No
@@ -13016,6 +13852,7 @@
 11	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 837
+# parallel_id = hk/837
 # text = 如果喺噉嘅情況之下，如果根據基本法七十一條所講呢，其實講緊居留權嘅，噉，我覺得呢個喺未澄清之前，係咪需要，欸，喺依一刻做依樣嘢呢？
 1	如果	如果	SCONJ	_	_	5	mark	_	SpaceAfter=No
 2	喺	喺	ADP	_	_	5	case	_	SpaceAfter=No
@@ -13065,6 +13902,7 @@
 46	？	？	PUNCT	_	_	26	punct	_	SpaceAfter=No
 
 # sent_id = 838
+# parallel_id = hk/838
 # text = 噉，我希望-你剛才提到依個規程問題，點樣規程法呢？
 1	噉	噉	ADV	_	_	4	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -13085,6 +13923,7 @@
 17	？	？	PUNCT	_	_	14	punct	_	SpaceAfter=No
 
 # sent_id = 839
+# parallel_id = hk/839
 # text = 就係你剛才話你嘅責任就係主持會議啦，同埋作出-有結果之後宣佈啦。
 1	就	就	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	係	係	VERB	_	_	0	root	_	SpaceAfter=No
@@ -13111,6 +13950,7 @@
 23	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 840
+# parallel_id = hk/840
 # text = 仲有一樣嘢，宣-會唔會係你嘅權力呢，就係，誒，adjourn成個會議。
 1	仲	重	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	有	有	VERB	_	_	0	root	_	SpaceAfter=No
@@ -13141,6 +13981,7 @@
 27	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 841
+# parallel_id = hk/841
 # text = 即係話睇依啲法律觀點，或者咁大風險之下，你覺得今日唔適宜作出今日選主席決定呢？
 1	即係話	即係話	ADV	_	_	14	advmod	_	SpaceAfter=No
 2	睇	睇	VERB	_	_	14	advcl	_	SpaceAfter=No
@@ -13168,12 +14009,14 @@
 24	？	？	PUNCT	_	_	14	punct	_	SpaceAfter=No
 
 # sent_id = 842
+# parallel_id = hk/842
 # text = 唔該主席。
 1	唔該	唔該	VERB	_	_	0	root	_	SpaceAfter=No
 2	主席	主席	NOUN	_	_	1	obj	_	SpaceAfter=No
 3	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 843
+# parallel_id = hk/843
 # text = 我係第一次參與呢個會議。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	係	係	VERB	_	_	0	root	_	SpaceAfter=No
@@ -13185,6 +14028,7 @@
 8	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 844
+# parallel_id = hk/844
 # text = 噉，就正如李慧瓊議員所言呢，其實今次個會議係好多人睇緊，亦都好多香港人關注。
 1	噉	噉	ADV	_	_	16	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -13215,6 +14059,7 @@
 27	。	。	PUNCT	_	_	16	punct	_	SpaceAfter=No
 
 # sent_id = 845
+# parallel_id = hk/845
 # text = 正正因為噉，我哋對自己嘅要求所以先至要更加高。
 1	正正	正正	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	因為	因為	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -13233,6 +14078,7 @@
 15	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No
 
 # sent_id = 846
+# parallel_id = hk/846
 # text = 即係我頭先見倒最大問題就係……
 1	即係	即係	ADV	_	_	10	advmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -13247,6 +14093,7 @@
 11	……	……	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 847
+# parallel_id = hk/847
 # text = 我而家仲係一個大學生。
 1	我	我	PRON	_	_	7	nsubj	_	SpaceAfter=No
 2	而家	而家	NOUN	_	_	7	obl:tmod	_	SpaceAfter=No
@@ -13258,6 +14105,7 @@
 8	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 848
+# parallel_id = hk/848
 # text = 佢呢個選舉，佢嚴謹嘅程度比一個大學生學生會嘅選舉更加不如。
 1	佢	佢	PRON	_	_	8	dislocated	_	SpaceAfter=No
 2	呢個	呢個	DET	_	_	3	det	_	SpaceAfter=No
@@ -13279,6 +14127,7 @@
 18	。	。	PUNCT	_	_	17	punct	_	SpaceAfter=No
 
 # sent_id = 849
+# parallel_id = hk/849
 # text = 即係你有咩可能，一個候選人，佢嘅國籍尚未確定，我哋就開展成個程序？
 1	即係	即係	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -13305,6 +14154,7 @@
 23	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 850
+# parallel_id = hk/850
 # text = 佢而家，祇不過係口頭上面話……
 1	佢	佢	PRON	_	_	5	nsubj	_	SpaceAfter=No
 2	而家	而家	NOUN	_	_	5	obl:tmod	_	SpaceAfter=No
@@ -13316,6 +14166,7 @@
 8	……	……	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 851
+# parallel_id = hk/851
 # text = 有人會話呢啲信件係可能已經證實咗，但呢個都祇不過係一個口頭上面嘅確認。
 1	有	有	VERB	_	_	0	root	_	SpaceAfter=No
 2	人	人	NOUN	_	_	1	obj	_	SpaceAfter=No
@@ -13342,6 +14193,7 @@
 23	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 852
+# parallel_id = hk/852
 # text = 而秘書處同埋主席，你，係應該-如果係對成個選舉係有責任或者係覺得成個立法會-我哋要取信於民，我哋要攞返市民嘅信任，我哋更加要將每一個程序做得更加緊，而唔係「按章工作」，即係秘書處佢話唔查就唔查，唔需要查就唔查。
 1	而	而	CCONJ	_	_	47	advmod	_	SpaceAfter=No
 2	秘書處	秘書處	NOUN	_	_	8	vocative	_	SpaceAfter=No
@@ -13421,6 +14273,7 @@
 76	。	。	PUNCT	_	_	47	punct	_	SpaceAfter=No
 
 # sent_id = 853
+# parallel_id = hk/853
 # text = 一個書面-一個有法律效力嘅文件，呢個係一個如此簡單嘅事情。
 1	一	一	NUM	_	_	3	nummod	_	SpaceAfter=No
 2	個	個	NOUN	_	NounType=Clf	1	clf	_	SpaceAfter=No
@@ -13445,6 +14298,7 @@
 21	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 854
+# parallel_id = hk/854
 # text = 我選立-我選呢個學生會，我都要畀個學生證佢睇下我係咪個學校嘅學生啦。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	選	選	VERB	_	_	6	reparandum	_	SpaceAfter=No
@@ -13474,6 +14328,7 @@
 26	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No
 
 # sent_id = 855
+# parallel_id = hk/855
 # text = 即係啲咁簡單嘅程序都完成唔到嘅話，成個立法會係不能夠取信於人㗎，主席。
 1	即係	即係	ADV	_	_	16	advmod	_	SpaceAfter=No
 2	啲	啲	NOUN	_	NounType=Clf	6	clf:det	_	SpaceAfter=No
@@ -13500,6 +14355,7 @@
 23	。	。	PUNCT	_	_	16	punct	_	SpaceAfter=No
 
 # sent_id = 856
+# parallel_id = hk/856
 # text = 呢個係第一個問題。
 1	呢個	呢個	PRON	_	_	5	nsubj	_	SpaceAfter=No
 2	係	係	AUX	_	_	5	cop	_	SpaceAfter=No
@@ -13509,6 +14365,7 @@
 6	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 857
+# parallel_id = hk/857
 # text = 第二個問題就係，而家我哋有幾多個人能夠投票，我哋都未搞得清楚。
 1	第二	第二	ADJ	_	_	3	amod	_	SpaceAfter=No
 2	個	個	NOUN	_	NounType=Clf	1	clf	_	SpaceAfter=No
@@ -13534,6 +14391,7 @@
 22	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 858
+# parallel_id = hk/858
 # text = 成個《議事規則》最大嘅精神就係我哋確保每一個議員都能夠-喺充足嘅情況同埋機會之下能夠完成倒個宣誓程序。
 1	成	成	DET	_	_	5	det	_	SpaceAfter=No
 2	個	個	NOUN	_	NounType=Clf	1	clf	_	SpaceAfter=No
@@ -13572,6 +14430,7 @@
 35	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No
 
 # sent_id = 859
+# parallel_id = hk/859
 # text = 而一個秘書長，佢唔能夠係基於完全冇法律理據，完全冇理由嘅一啲質疑，用佢個人嘅判斷係同佢-係同其他議員講佢係冇能力係主持呢個監誓。
 1	而	而	CCONJ	_	_	9	advmod	_	SpaceAfter=No
 2	一	一	NUM	_	_	4	nummod	_	SpaceAfter=No
@@ -13620,6 +14479,7 @@
 45	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 860
+# parallel_id = hk/860
 # text = 我會認為就係呢樣嘢就係完全違反咗《議事規則》本身應該要有嘅精神。
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	會	會	AUX	_	_	3	aux	_	SpaceAfter=No
@@ -13647,6 +14507,7 @@
 24	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 861
+# parallel_id = hk/861
 # text = 就係要佢，或者要所有議員，係能夠成功噉樣完成個程序，然後進入去主席嘅選舉。
 1	就	就	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	係	係	VERB	_	_	0	root	_	SpaceAfter=No
@@ -13675,6 +14536,7 @@
 25	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 862
+# parallel_id = hk/862
 # text = 所以呢一個-秘書長陳維安佢頭先嘅決定呢，或者判斷呢，其實係-完全係一個arbitrary_use_of_power，係完全係，冇任何基礎嘅一個判斷嚟㗎。
 1	所以	所以	ADV	_	_	25	advmod	_	SpaceAfter=No
 2	呢	呢	DET	_	_	4	det	_	SpaceAfter=No
@@ -13718,6 +14580,7 @@
 40	。	。	PUNCT	_	_	25	punct	_	SpaceAfter=No
 
 # sent_id = 863
+# parallel_id = hk/863
 # text = 如果大家睇返之前嘅片段呢，其實三位議員佢都完整噉樣讀完佢嘅誓詞。
 1	如果	如果	SCONJ	_	_	3	mark	_	SpaceAfter=No
 2	大家	大家	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -13744,6 +14607,7 @@
 23	。	。	PUNCT	_	_	18	punct	_	SpaceAfter=No
 
 # sent_id = 864
+# parallel_id = hk/864
 # text = 而喺《議事規則》裏面，祇不過係規定議員完絕-完整噉樣讀完個誓詞。
 1	而	而	CCONJ	_	_	10	advmod	_	SpaceAfter=No
 2	喺	喺	ADP	_	_	5	case	_	SpaceAfter=No
@@ -13768,6 +14632,7 @@
 21	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 865
+# parallel_id = hk/865
 # text = 佢語氣或者其他嘢，佢根本就唔能夠基於呢樣嘢作一個標準就係話自己冇-即係判斷自己冇權去監誓。
 1	佢	佢	PRON	_	_	2	compound	_	SpaceAfter=No
 2	語氣	語氣	NOUN	_	_	12	dislocated	_	SpaceAfter=No
@@ -13804,6 +14669,7 @@
 33	。	。	PUNCT	_	_	16	punct	_	SpaceAfter=No
 
 # sent_id = 866
+# parallel_id = hk/866
 # text = 噉，所以我希望主席你明白而家有兩個好大問題擺喺我哋面前。
 1	噉	噉	ADV	_	_	5	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -13827,6 +14693,7 @@
 20	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 867
+# parallel_id = hk/867
 # text = 如果我哋唔去處理佢，然後再進行主席嘅選舉嘅話呢，即係立法會係好難去取信於人。
 1	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No
 2	我哋	我哋	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -13854,6 +14721,7 @@
 24	。	。	PUNCT	_	_	19	punct	_	SpaceAfter=No
 
 # sent_id = 868
+# parallel_id = hk/868
 # text = 而我相信好多議員，即係包括好多直選，有好多民意基礎支持嘅議員呢，亦都唔能夠信納呢個選舉嘅結果。
 1	而	而	CCONJ	_	_	3	advmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -13886,6 +14754,7 @@
 29	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 869
+# parallel_id = hk/869
 # text = 主席，呢一個，係香港人面前睇倒粗疏到不能再粗疏嘅程序。
 1	主席	主席	NOUN	_	_	20	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -13910,6 +14779,7 @@
 21	。	。	PUNCT	_	_	20	punct	_	SpaceAfter=No
 
 # sent_id = 870
+# parallel_id = hk/870
 # text = 假如，佢-梁君彥係連正本都攞唔倒出嚟。
 1	假如	假如	SCONJ	_	_	3	mark	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	3	punct	_	SpaceAfter=No
@@ -13927,6 +14797,7 @@
 14	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 871
+# parallel_id = hk/871
 # text = 大家睇倒而家講緊嘅，佢係攞住一個，即係副本不似副本嘅文件去證明自己嘅國籍。
 1	大家	大家	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	睇	睇	VERB	_	_	0	root	_	SpaceAfter=No
@@ -13958,6 +14829,7 @@
 28	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 872
+# parallel_id = hk/872
 # text = 而最糟糕嘅地方就係，連個居留權，都未釐清倒。
 1	而	而	CCONJ	_	_	7	advmod	_	SpaceAfter=No
 2	最	最	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -13978,6 +14850,7 @@
 17	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 873
+# parallel_id = hk/873
 # text = 假如今日喺一個咁粗疏嘅情況之下進入程序嘅話呢，即係畀佢「過倒海係神仙」㗎嘑，主席。
 1	假如	假如	SCONJ	_	_	11	mark	_	SpaceAfter=No
 2	今日	今日	NOUN	_	_	11	obl:tmod	_	SpaceAfter=No
@@ -14011,6 +14884,7 @@
 30	。	。	PUNCT	_	_	17	punct	_	SpaceAfter=No
 
 # sent_id = 874
+# parallel_id = hk/874
 # text = 梁君彥如果過倒海呢，佢義不容辭呀，真係。
 1	梁君彥	梁君彥	PROPN	_	_	3	nsubj	_	SpaceAfter=No
 2	如果	如果	SCONJ	_	_	3	mark	_	SpaceAfter=No
@@ -14028,6 +14902,7 @@
 14	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 875
+# parallel_id = hk/875
 # text = 所以我唔覺得，喺呢度會問嘅問題-大家問題，其實我-係好具體㗎。
 1	所以	所以	ADV	_	_	4	advmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -14054,6 +14929,7 @@
 23	。	。	PUNCT	_	_	21	punct	_	SpaceAfter=No
 
 # sent_id = 876
+# parallel_id = hk/876
 # text = 佢哋嘅候選人資格，以至我哋在坐可以投票嘅人嘅資格，我哋都未能夠釐清倒。
 1	佢哋	佢哋	PRON	_	_	4	nmod	_	SpaceAfter=No
 2	嘅	嘅	PART	_	_	1	case	_	SpaceAfter=No
@@ -14079,6 +14955,7 @@
 22	。	。	PUNCT	_	_	20	punct	_	SpaceAfter=No
 
 # sent_id = 877
+# parallel_id = hk/877
 # text = 喺咁混亂嘅情況之下，咁粗疏嘅情況之下進入程序，主席，我怕你背負嘅壓力會好大喎。
 1	喺	喺	ADP	_	_	5	case	_	SpaceAfter=No
 2	咁	咁	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -14109,6 +14986,7 @@
 27	。	。	PUNCT	_	_	25	punct	_	SpaceAfter=No
 
 # sent_id = 878
+# parallel_id = hk/878
 # text = 所以我都係，希望主席你能夠-即係，請靜-請耐心，請聆聽我哋會眾嘅意見，作出你嘅裁決。
 1	所以	所以	ADV	_	_	4	advmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -14142,6 +15020,7 @@
 30	。	。	PUNCT	_	_	16	punct	_	SpaceAfter=No
 
 # sent_id = 879
+# parallel_id = hk/879
 # text = 如果喺一個咁唔服眾嘅情況之下進入一個噉嘅程序嘅話呢，香港人會睇倒嘅。
 1	如果	如果	SCONJ	_	_	11	mark	_	SpaceAfter=No
 2	喺	喺	ADP	_	_	9	case	_	SpaceAfter=No
@@ -14171,12 +15050,14 @@
 26	。	。	PUNCT	_	_	23	punct	_	SpaceAfter=No
 
 # sent_id = 880
+# parallel_id = hk/880
 # text = 唔該主席。
 1	唔該	唔該	VERB	_	_	0	root	_	SpaceAfter=No
 2	主席	主席	NOUN	_	_	1	obj	_	SpaceAfter=No
 3	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 881
+# parallel_id = hk/881
 # text = 主席，我完全唔能夠接受你所講-頭先所講話「祇有立法會嘅主席先至有居留權嘅限制，候選人冇」。
 1	主席	主席	NOUN	_	_	7	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -14210,6 +15091,7 @@
 30	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 882
+# parallel_id = hk/882
 # text = 喺呢一刻，如果我哋進行投票，當選嘅人下一刻就已經成為我哋嘅主席。
 1	喺	喺	ADP	_	_	4	case	_	SpaceAfter=No
 2	呢	呢	DET	_	_	4	det	_	SpaceAfter=No
@@ -14236,6 +15118,7 @@
 23	。	。	PUNCT	_	_	19	punct	_	SpaceAfter=No
 
 # sent_id = 883
+# parallel_id = hk/883
 # text = 喺呢一刻，我哋絕對係有義務要去釐清佢已經完成晒一切嘅放棄居留權嘅手續，並且交出正本，嚟以示-以正-以正視聽。
 1	喺	喺	ADP	_	_	4	case	_	SpaceAfter=No
 2	呢	呢	DET	_	_	4	det	_	SpaceAfter=No
@@ -14279,6 +15162,7 @@
 40	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 884
+# parallel_id = hk/884
 # text = 而秘書處係有責任去維護呢件事，係正確噉樣，完成噉樣，誒-完整噉樣進行。
 1	而	而	CCONJ	_	_	3	advmod	_	SpaceAfter=No
 2	秘書處	秘書處	NOUN	_	_	3	nsubj	_	SpaceAfter=No
@@ -14306,6 +15190,7 @@
 24	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 885
+# parallel_id = hk/885
 # text = 所以，我認為，喺呢一刻，如果梁君彥議員仍然都係交唔出，佢嗰封信，抌有正規嘅印嘅正本嘅話，其實佢係應該冇資格參選嘅。
 1	所以	所以	ADV	_	_	4	advmod	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -14352,6 +15237,7 @@
 43	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 886
+# parallel_id = hk/886
 # text = 究竟呢個投票箱入便，有兩個投票箱：廢票同塗謹申議員，定係加埋梁君彥議員？
 1	究竟	究竟	ADV	_	_	7	advmod	_	SpaceAfter=No
 2	呢	呢	DET	_	_	4	det	_	SpaceAfter=No
@@ -14377,6 +15263,7 @@
 22	？	？	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 887
+# parallel_id = hk/887
 # text = 係好決定我哋未來呢個立法會任期入便呢啲會議係點樣進行，係對全香港人嘅公眾利益都係，即係非常重大嘅關係。
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	好	好	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -14414,6 +15301,7 @@
 34	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 888
+# parallel_id = hk/888
 # text = 我認為喺呢一刻，我哋就一定要去處理呢一件事。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	認為	認為	VERB	_	_	0	root	_	SpaceAfter=No
@@ -14435,6 +15323,7 @@
 18	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 889
+# parallel_id = hk/889
 # text = 如果梁君彥議員交唔出佢呢份文件嘅正本嘅話，噉，佢應該係冇參選嘅資格。
 1	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No
 2	梁君彥	梁君彥	PROPN	_	_	4	nsubj	_	SpaceAfter=No
@@ -14462,6 +15351,7 @@
 24	。	。	PUNCT	_	_	19	punct	_	SpaceAfter=No
 
 # sent_id = 890
+# parallel_id = hk/890
 # text = 誒m，我剛才祇不過依書直說唧，我祇係根據《基本法》嗰個-朗讀畀大家聽唧，冇，我冇參與我個人嘅意見落去。
 1	誒m	誒m	PART	_	_	6	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -14499,6 +15389,7 @@
 34	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 891
+# parallel_id = hk/891
 # text = 因為我主席都唔可以畀一個個人嘅意見，況且依啲係一個，誒m，又係憲制，又係法律嘅問題呢，噉，我唔畀任何嘅意見落去嘞。
 1	因為	因為	ADV	_	_	7	advmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	7	nsubj	_	SpaceAfter=No
@@ -14545,6 +15436,7 @@
 43	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 892
+# parallel_id = hk/892
 # text = 我畀都未必係最正確嘅。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	畀	畀	VERB	_	_	7	advcl	_	SpaceAfter=No
@@ -14557,6 +15449,7 @@
 9	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 893
+# parallel_id = hk/893
 # text = 噉，就至於個-想同大家講講噉解唧。
 1	噉	噉	ADV	_	_	10	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -14573,6 +15466,7 @@
 13	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 894
+# parallel_id = hk/894
 # text = 呀，噉嘅，我就-其實任何一個選舉裏便呢，不論係我哋以前做學生會嘅選舉，以至到今日我哋選主席……
 1	呀	呀	INTJ	_	_	24	discourse:sp	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -14608,6 +15502,7 @@
 32	……	……	PUNCT	_	_	24	punct	_	SpaceAfter=No
 
 # sent_id = 895
+# parallel_id = hk/895
 # text = 呢個-而家係一個正式嘅會議嘅話，梁頌恒議員係冇資格參加呢個會議。
 1	呢個	呢個	PRON	_	_	9	reparandum	_	SpaceAfter=No
 2	-	-	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -14632,6 +15527,7 @@
 21	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No
 
 # sent_id = 896
+# parallel_id = hk/896
 # text = 主席呀，我而家有冇管-我第一個問題，我修正吖。
 1	主席	主席	NOUN	_	_	13	vocative	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -14653,6 +15549,7 @@
 18	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No
 
 # sent_id = 897
+# parallel_id = hk/897
 # text = 我而家有冇權參加呢一個會議呀？
 1	我	我	PRON	_	_	6	nsubj	_	SpaceAfter=No
 2	而家	而家	NOUN	_	_	6	obl:tmod	_	SpaceAfter=No
@@ -14668,6 +15565,7 @@
 12	？	？	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 898
+# parallel_id = hk/898
 # text = 任何未宣誓嘅議員，根據我哋《議事規則》同埋法例，係唔能夠參加正式會議，係唔能夠發言㗎，主席。
 1	任何	任何	DET	_	_	5	det	_	SpaceAfter=No
 2	未	未	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -14701,6 +15599,7 @@
 30	。	。	PUNCT	_	_	16	punct	_	SpaceAfter=No
 
 # sent_id = 899
+# parallel_id = hk/899
 # text = 噉，我下一個問題嚟嘑，主席。
 1	噉	噉	ADV	_	_	8	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -14716,6 +15615,7 @@
 12	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 900
+# parallel_id = hk/900
 # text = 喺《議事規則》裏便，第十二條《每屆任期初次會議》。
 1	喺	喺	ADP	_	_	4	case	_	SpaceAfter=No
 2	《	《	PUNCT	_	_	4	punct	_	SpaceAfter=No
@@ -14737,6 +15637,7 @@
 18	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 901
+# parallel_id = hk/901
 # text = 喺立法會每屆任期首次會議上面，議員，係需要按照本議事規則第一條，括弧，《宗教式或者非宗教式宣誓》嘅規定作宗教式或者非宗教式嘅宣誓嘅。
 1	喺	喺	ADP	_	_	8	case	_	SpaceAfter=No
 2	立法會	立法會	NOUN	_	_	8	compound	_	SpaceAfter=No
@@ -14783,6 +15684,7 @@
 43	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No
 
 # sent_id = 902
+# parallel_id = hk/902
 # text = 第二，喺所有出席會議……「──即係包括我──」作宗教式，或者非宗教式宣誓後，需要按照本議事規則第四條《立法會主席選擧》規定嘅程序而進行立法會主席嘅選擧。
 1	第二	第二	ADJ	_	_	42	amod	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -14833,6 +15735,7 @@
 47	。	。	PUNCT	_	_	42	punct	_	SpaceAfter=No
 
 # sent_id = 903
+# parallel_id = hk/903
 # text = 呢個係有先後次序嘅問題㗎，主席。
 1	呢個	呢個	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	係	係	VERB	_	_	0	root	_	SpaceAfter=No
@@ -14847,6 +15750,7 @@
 11	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 904
+# parallel_id = hk/904
 # text = 我們都未完成第一點，就係所有出席咗呢個會議嘅議員，去進行宣誓。
 1	我們	我們	PRON	_	_	4	nsubj	_	SpaceAfter=No
 2	都	都	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -14871,6 +15775,7 @@
 21	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 905
+# parallel_id = hk/905
 # text = 我哋又點去到第二點，去選立法會嘅主席呢？
 1	我哋	我哋	PRON	_	_	4	nsubj	_	SpaceAfter=No
 2	又	又	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -14889,6 +15794,7 @@
 15	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 906
+# parallel_id = hk/906
 # text = 呢一個係好嚴重嘅規程問題嚟㗎，主席。
 1	呢	呢	DET	_	_	3	det	_	SpaceAfter=No
 2	一	一	NUM	_	_	3	nummod	_	SpaceAfter=No
@@ -14906,6 +15812,7 @@
 14	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 907
+# parallel_id = hk/907
 # text = 誒，其實呢，就，我容許其他嘅議員呢，在坐喺依度嘅話呢，其實我就唔去作任何決定，唔畀人哋發言嘅，因為我已經畀咗人哋坐喺度㗎嘞。
 1	誒	誒	INTJ	_	_	25	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -14955,6 +15862,7 @@
 46	。	。	PUNCT	_	_	25	punct	_	SpaceAfter=No
 
 # sent_id = 908
+# parallel_id = hk/908
 # text = 噉，我就要畀佢繼續發言落去。
 1	噉	噉	ADV	_	_	6	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -14969,6 +15877,7 @@
 11	。	。	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 909
+# parallel_id = hk/909
 # text = 主席，如果你確認呢個係正式嘅會議嘅話呢，你噉樣係嚴重去……《議事規則》第一條㗎。
 1	主席	主席	NOUN	_	_	16	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -14999,6 +15908,7 @@
 27	。	。	PUNCT	_	_	16	punct	_	SpaceAfter=No
 
 # sent_id = 910
+# parallel_id = hk/910
 # text = 我希望你重新考慮呢個問題。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	希望	希望	VERB	_	_	0	root	_	SpaceAfter=No
@@ -15010,6 +15920,7 @@
 8	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 911
+# parallel_id = hk/911
 # text = 改選主席，我認為係。
 1	改選	改選	VERB	_	_	6	ccomp	_	SpaceAfter=No
 2	主席	主席	NOUN	_	_	1	obj	_	SpaceAfter=No
@@ -15020,6 +15931,7 @@
 7	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 912
+# parallel_id = hk/912
 # text = 繼續響應阿-阿謝偉俊議員。
 1	繼續	繼續	VERB	_	_	0	root	_	SpaceAfter=No
 2	響應	響應	VERB	_	_	1	xcomp	_	SpaceAfter=No
@@ -15031,6 +15943,7 @@
 8	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 913
+# parallel_id = hk/913
 # text = 佢唔稱任。
 1	佢	佢	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -15038,6 +15951,7 @@
 4	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 914
+# parallel_id = hk/914
 # text = 我認為要改選主席。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	認為	認為	VERB	_	_	0	root	_	SpaceAfter=No
@@ -15047,6 +15961,7 @@
 6	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 915
+# parallel_id = hk/915
 # text = 誒，你可以質疑我依個嘅決定嘅，可以質疑我嘅決定，但係不過我做咗依個決定出嚟。
 1	誒	誒	INTJ	_	_	5	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -15076,6 +15991,7 @@
 26	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 916
+# parallel_id = hk/916
 # text = 下，噉，我就，就會係，喺-在坐嘅議員呢，係經過選舉嗰度呢，確認咗佢係議員嘅話呢，雖然佢未宣誓，我係畀佢喺依度呢，係發-發言㗎。
 1	下	下	INTJ	_	_	10	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -15130,6 +16046,7 @@
 51	。	。	PUNCT	_	_	39	punct	_	SpaceAfter=No
 
 # sent_id = 917
+# parallel_id = hk/917
 # text = 你-你可以有你嘅決定。
 1	你	你	PRON	_	_	3	reparandum	_	SpaceAfter=No
 2	-	-	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -15142,6 +16059,7 @@
 9	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 918
+# parallel_id = hk/918
 # text = 不過我想知你嘅決定係建基於你認為有關議員是否應該正式宣誓之後做，定話唔做？
 1	不過	不過	CCONJ	_	_	4	advmod	_	SpaceAfter=No
 2	我	我	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -15170,6 +16088,7 @@
 25	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 919
+# parallel_id = hk/919
 # text = 如果你又認為佢嘅宣誓有效，你畀佢做，你可以決定，可以有基礎。
 1	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No
 2	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -15195,6 +16114,7 @@
 22	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 920
+# parallel_id = hk/920
 # text = 但係如果你都同意有關宣誓係唔合理、唔合法嘅話呢，你噉樣做法係嚴重違反《議事規則》第一條呢，係唔能夠進行。
 1	但係	但係	CCONJ	_	_	20	advmod	_	SpaceAfter=No
 2	如果	如果	SCONJ	_	_	5	mark	_	SpaceAfter=No
@@ -15233,6 +16153,7 @@
 35	。	。	PUNCT	_	_	20	punct	_	SpaceAfter=No
 
 # sent_id = 921
+# parallel_id = hk/921
 # text = 誒，因為呢，當任何議員未曾做依一個嘅最後嘅宣誓嘅時候呢，佢仍然都有議員嘅-嘅，唔係-係有資格，佢身份裏便嚟講嘅話呢。
 1	誒	誒	INTJ	_	_	25	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -15281,6 +16202,7 @@
 45	。	。	PUNCT	_	_	25	punct	_	SpaceAfter=No
 
 # sent_id = 922
+# parallel_id = hk/922
 # text = 當然，你可以話未做s-未做宣誓，未係-未係嗰個議員。
 1	當然	當然	ADV	_	_	5	advmod	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -15306,6 +16228,7 @@
 22	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 923
+# parallel_id = hk/923
 # text = 但不過問題在於，噉，我-剛才你未宣誓，我都畀你坐喺度個喎。
 1	但	但	ADV	_	_	4	advmod	_	SpaceAfter=No
 2	不過	不過	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -15331,6 +16254,7 @@
 22	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 924
+# parallel_id = hk/924
 # text = 噉，你點解釋呢？
 1	噉	噉	ADV	_	_	5	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -15341,6 +16265,7 @@
 7	？	？	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 925
+# parallel_id = hk/925
 # text = 主席，但係當你已經話宣布呢，已經進入第二階段，選主席階段呢，你已經確認咗，第一階段嘅一個宣誓儀式已經完成咗。
 1	主席	主席	NOUN	_	_	23	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -15380,6 +16305,7 @@
 36	。	。	PUNCT	_	_	23	punct	_	SpaceAfter=No
 
 # sent_id = 926
+# parallel_id = hk/926
 # text = 所以，呢個係邏輯上，你唔好搞錯咗先，如果唔係嘅話，你噉樣做法係冇可能嘅。
 1	所以	所以	ADV	_	_	5	advmod	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -15411,6 +16337,7 @@
 28	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 927
+# parallel_id = hk/927
 # text = 冇錯，你講得啱嘅，就係……你講得啱嘅。
 1	冇	冇	VERB	_	_	0	root	_	SpaceAfter=No
 2	錯	錯	NOUN	_	_	1	obj	_	SpaceAfter=No
@@ -15432,6 +16359,7 @@
 18	。	。	PUNCT	_	_	14	punct	_	SpaceAfter=No
 
 # sent_id = 928
+# parallel_id = hk/928
 # text = 但係不過問題在於就係咩呢？仲未有人去取消佢資格，佢未宣誓。
 1	但係	但係	ADV	_	_	4	advmod	_	SpaceAfter=No
 2	不過	不過	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -15457,6 +16385,7 @@
 22	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 929
+# parallel_id = hk/929
 # text = 剛才你坐喺度嗰陣時候呢，亦都冇人去取消你資格，所以仍然呢，係畀你有資格去宣誓。
 1	剛才	剛才	ADV	_	_	3	advmod	_	SpaceAfter=No
 2	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -15489,6 +16418,7 @@
 29	。	。	PUNCT	_	_	22	punct	_	SpaceAfter=No
 
 # sent_id = 930
+# parallel_id = hk/930
 # text = 我係話佢發言呀，主席。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	係	係	VERB	_	_	0	root	_	SpaceAfter=No
@@ -15501,6 +16431,7 @@
 9	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 931
+# parallel_id = hk/931
 # text = 唔係講取消資格。
 1	唔	唔	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	係	係	VERB	_	_	0	root	_	SpaceAfter=No
@@ -15510,6 +16441,7 @@
 6	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 932
+# parallel_id = hk/932
 # text = 嗰啲我哋下一步會做。
 1	嗰啲	嗰啲	PRON	_	_	7	obj:periph	_	SpaceAfter=No
 2	我哋	我哋	PRON	_	_	7	nsubj	_	SpaceAfter=No
@@ -15521,6 +16453,7 @@
 8	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 933
+# parallel_id = hk/933
 # text = 我，話第一階程完咗之後呢，先有資格去第二階段參與-參與會議呀。
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	3	punct	_	SpaceAfter=No
@@ -15546,6 +16479,7 @@
 22	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No
 
 # sent_id = 934
+# parallel_id = hk/934
 # text = 冇錯，你講得啱，你可以質疑我依個做法。
 1	冇	冇	VERB	_	_	0	root	_	SpaceAfter=No
 2	錯	錯	NOUN	_	_	1	obj	_	SpaceAfter=No
@@ -15564,6 +16498,7 @@
 15	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 935
+# parallel_id = hk/935
 # text = 但係不過我覺得呢，我依據剛才嘅程序裏便嚟講嘅話呢，因為-因為你哋大家未宣誓嗰陣時呢，都有資格坐喺依個議-會議廳嗰度嘅話呢，我用依一個概念。
 1	但係	但係	ADV	_	_	4	advmod	_	SpaceAfter=No
 2	不過	不過	ADV	_	_	4	advmod	_	SpaceAfter=No
@@ -15614,6 +16549,7 @@
 47	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 936
+# parallel_id = hk/936
 # text = 你問我個理由呢，我解釋畀你聽嘞。
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	問	問	VERB	_	_	0	root	_	SpaceAfter=No
@@ -15631,6 +16567,7 @@
 14	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 937
+# parallel_id = hk/937
 # text = 無論你接受與唔接受都好，無論你覺得我依個擉-決定啱與唔啱都好……
 1	無論	無論	SCONJ	_	_	8	mark	_	SpaceAfter=No
 2	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -15658,6 +16595,7 @@
 24	……	……	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 938
+# parallel_id = hk/938
 # text = 如果你仍然當我係主席嘅話呢，叫得我做主席嘅話呢，你要接受我依個決定。
 1	如果	如果	SCONJ	_	_	4	mark	_	SpaceAfter=No
 2	你	你	PRON	_	_	4	nsubj	_	SpaceAfter=No
@@ -15686,6 +16624,7 @@
 25	。	。	PUNCT	_	_	21	punct	_	SpaceAfter=No
 
 # sent_id = 939
+# parallel_id = hk/939
 # text = 除非你係唔覺得我就係主席呢，你就唔使再聽我依個決定，ＯＫ？
 1	除非	除非	SCONJ	_	_	3	mark	_	SpaceAfter=No
 2	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
@@ -15711,6 +16650,7 @@
 22	？	？	PUNCT	_	_	16	punct	_	SpaceAfter=No
 
 # sent_id = 940
+# parallel_id = hk/940
 # text = 梁頌恆議員呢，係咪繼續係發言……
 1	梁頌恆	梁頌恆	PROPN	_	_	6	vocative	_	SpaceAfter=No
 2	議員	議員	NOUN	_	_	1	flat	_	SpaceAfter=No
@@ -15723,6 +16663,7 @@
 9	……	……	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 941
+# parallel_id = hk/941
 # text = 阿代理主席，阿代理主席，你就真係唔係好想做「醜人」嘅，我知你嘅，但係你唔可以違反我哋嘅《議事規則》㗎。
 1	阿	阿	PART	_	_	3	compound	_	SpaceAfter=No
 2	代理	代理	ADJ	_	_	3	amod	_	SpaceAfter=No
@@ -15766,6 +16707,7 @@
 40	。	。	PUNCT	_	_	12	punct	_	SpaceAfter=No
 
 # sent_id = 942
+# parallel_id = hk/942
 # text = 《議事規則》第一條已經講明，未宣誓係唔能夠參與會議咖嘛，主席！
 1	《	《	PUNCT	_	_	3	punct	_	SpaceAfter=No
 2	議事	議事	VERB	_	_	3	acl	_	SpaceAfter=No
@@ -15790,6 +16732,7 @@
 21	！	！	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 943
+# parallel_id = hk/943
 # text = 唔好意思，唔好意思，我剛才已經做咗決定出嚟，你可以質疑我嘅決定。
 1	唔好意思	唔好意思	INTJ	_	_	8	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -15812,6 +16755,7 @@
 19	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 944
+# parallel_id = hk/944
 # text = 我知你唔想做「醜人」，但係你都冇權力可以去overrule我哋個《議事規則》去做你呢個決定㗎。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	知	知	VERB	_	_	0	root	_	SpaceAfter=No
@@ -15846,6 +16790,7 @@
 31	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 945
+# parallel_id = hk/945
 # text = 你根本冇power去做呢個決定㗎。
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	根本	根本	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -15859,6 +16804,7 @@
 10	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 946
+# parallel_id = hk/946
 # text = 嗱，我都講咗嘞。
 1	嗱	嗱	INTJ	_	_	5	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -15870,6 +16816,7 @@
 8	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 947
+# parallel_id = hk/947
 # text = 我做決定有-可以錯，可以對。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	做	做	VERB	_	_	7	csubj	_	SpaceAfter=No
@@ -15884,6 +16831,7 @@
 11	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 948
+# parallel_id = hk/948
 # text = 無論錯與對都好呢，今日我-我唔會同你爭論嘅，我唔會同你爭論嘅。
 1	無論	無論	SCONJ	_	_	6	mark	_	SpaceAfter=No
 2	錯	錯	ADJ	_	_	6	csubj	_	SpaceAfter=No
@@ -15914,6 +16862,7 @@
 27	。	。	PUNCT	_	_	17	punct	_	SpaceAfter=No
 
 # sent_id = 949
+# parallel_id = hk/949
 # text = 呢個錯嘅決定，係咪？
 1	呢個	呢個	PRON	_	_	4	nsubj	_	SpaceAfter=No
 2	錯	錯	ADJ	_	_	4	amod	_	SpaceAfter=No
@@ -15924,6 +16873,7 @@
 7	？	？	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 950
+# parallel_id = hk/950
 # text = 你要做一個違反我哋《議事規則》嘅決定？
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	要	要	AUX	_	_	3	aux	_	SpaceAfter=No
@@ -15941,6 +16891,7 @@
 14	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 951
+# parallel_id = hk/951
 # text = 我已經做咗決定出嚟呢，就係做咗決定。
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	已經	已經	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -15958,6 +16909,7 @@
 14	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 952
+# parallel_id = hk/952
 # text = 你唔同意我決定嘅話呢，你可以去法庭上高，去質疑我依個決定。
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -15981,6 +16933,7 @@
 20	。	。	PUNCT	_	_	11	punct	_	SpaceAfter=No
 
 # sent_id = 953
+# parallel_id = hk/953
 # text = 噉，點解你唔同佢哋講呀？
 1	噉	噉	ADV	_	_	8	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -15994,6 +16947,7 @@
 10	？	？	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 954
+# parallel_id = hk/954
 # text = 你唔叫佢哋去法庭上高，執行你決定嘅決定呀？
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -16012,6 +16966,7 @@
 15	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 955
+# parallel_id = hk/955
 # text = 我而家決定咗囖！
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	而家	而家	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No
@@ -16021,6 +16976,7 @@
 6	！	！	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 956
+# parallel_id = hk/956
 # text = 點解你唔將呢句說話-點解你同我講，唔同你隔籬嗰啲人講呀？
 1	點解	點解	ADV	_	_	7	advmod	_	SpaceAfter=No
 2	你	你	PRON	_	_	7	nsubj	_	SpaceAfter=No
@@ -16047,6 +17003,7 @@
 23	？	？	PUNCT	_	_	13	punct	_	SpaceAfter=No
 
 # sent_id = 957
+# parallel_id = hk/957
 # text = 我已經畀佢發言囖。
 1	我	我	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	已經	已經	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -16057,6 +17014,7 @@
 7	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 958
+# parallel_id = hk/958
 # text = 梁耀忠，唔好噉樣啦！
 1	梁耀忠	梁耀忠	PROPN	_	_	5	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -16067,6 +17025,7 @@
 7	！	！	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 959
+# parallel_id = hk/959
 # text = 你可唔可以中立啲？可唔可以公正啲，跟返《議事規則》做呀？
 1	你	你	PRON	_	_	5	nsubj	_	SpaceAfter=No
 2	可	可以	AUX	_	_	5	aux	_	SpaceAfter=No
@@ -16092,6 +17051,7 @@
 22	？	？	PUNCT	_	_	20	punct	_	SpaceAfter=No
 
 # sent_id = 960
+# parallel_id = hk/960
 # text = 我知你唔會做「醜人」，我哋都唔想為難你。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	知	知	VERB	_	_	0	root	_	SpaceAfter=No
@@ -16112,6 +17072,7 @@
 17	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 961
+# parallel_id = hk/961
 # text = 你跟返《議事規則》咪得囖。
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	跟	跟	VERB	_	_	9	advcl	_	SpaceAfter=No
@@ -16126,6 +17087,7 @@
 11	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 962
+# parallel_id = hk/962
 # text = 根據《議事規則》呢，我做嘅決定就係最後決定嚟㗎嘞。
 1	根據	根據	ADP	_	_	4	case	_	SpaceAfter=No
 2	《	《	PUNCT	_	_	4	punct	_	SpaceAfter=No
@@ -16148,6 +17110,7 @@
 19	。	。	PUNCT	_	_	15	punct	_	SpaceAfter=No
 
 # sent_id = 963
+# parallel_id = hk/963
 # text = 主席，主席，主席，規程問題，規程問題。
 1	主席	主席	NOUN	_	_	8	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -16163,6 +17126,7 @@
 12	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 964
+# parallel_id = hk/964
 # text = 請大家坐低先。
 1	請	請	VERB	_	_	0	root	_	SpaceAfter=No
 2	大家	大家	PRON	_	_	1	obj	_	SpaceAfter=No
@@ -16172,6 +17136,7 @@
 6	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 965
+# parallel_id = hk/965
 # text = 規程問題，規程問題，首先我-我希望主席……立法會係一個莊嚴嘅地方。
 1	規程	規程	NOUN	_	_	2	compound	_	SpaceAfter=No
 2	問題	問題	NOUN	_	_	0	root	_	SpaceAfter=No
@@ -16196,6 +17161,7 @@
 21	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 966
+# parallel_id = hk/966
 # text = 希望你請嗰啲喺出便嘅議員返返去嗰個位嗰度。
 1	希望	希望	VERB	_	_	0	root	_	SpaceAfter=No
 2	你	你	PRON	_	_	1	obj	_	SpaceAfter=No
@@ -16214,6 +17180,7 @@
 15	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 967
+# parallel_id = hk/967
 # text = 請大家坐低先，請大家靜下先，請靜下先，請靜下先，請大家靜下先。
 1	請	請	VERB	_	_	0	root	_	SpaceAfter=No
 2	大家	大家	PRON	_	_	1	obj	_	SpaceAfter=No
@@ -16245,6 +17212,7 @@
 28	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 968
+# parallel_id = hk/968
 # text = 梁美芬議員，請你坐低！
 1	梁美芬	梁美芬	PROPN	_	_	4	vocative	_	SpaceAfter=No
 2	議員	議員	NOUN	_	_	1	flat	_	SpaceAfter=No
@@ -16256,6 +17224,7 @@
 8	！	！	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 969
+# parallel_id = hk/969
 # text = 冇錯，點解你而家可以講嘢，我而家唔係-我而家唔係霸尖。
 1	冇	冇	VERB	_	_	0	root	_	SpaceAfter=No
 2	錯	錯	NOUN	_	_	1	obj	_	SpaceAfter=No
@@ -16279,6 +17248,7 @@
 20	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 970
+# parallel_id = hk/970
 # text = 主席，我希望呢，喺出便嘅議員，係可以返返佢嘅座位裏面，因為我哋覺得好騷擾。
 1	主席	主席	NOUN	_	_	4	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	4	punct	_	SpaceAfter=No
@@ -16308,6 +17278,7 @@
 26	。	。	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 971
+# parallel_id = hk/971
 # text = 我哋希望係，主席一個人喺度主持會議。
 1	我哋	我哋	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	希望	希望	VERB	_	_	0	root	_	SpaceAfter=No
@@ -16323,6 +17294,7 @@
 12	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 972
+# parallel_id = hk/972
 # text = 你唔係有五個人喺度垂簾聽政呀，下馬？
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -16339,6 +17311,7 @@
 13	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 973
+# parallel_id = hk/973
 # text = 你唔係需要呢啲人保護你呀，下馬？
 1	你	你	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	唔	唔	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -16354,12 +17327,14 @@
 12	？	？	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 974
+# parallel_id = hk/974
 # text = 梁美芬教授……
 1	梁美芬	梁美芬	PROPN	_	_	0	root	_	SpaceAfter=No
 2	教授	教授	NOUN	_	_	1	flat	_	SpaceAfter=No
 3	……	……	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 975
+# parallel_id = hk/975
 # text = 我覺得我哋非常受騷擾。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	覺得	覺得	VERB	_	_	0	root	_	SpaceAfter=No
@@ -16370,6 +17345,7 @@
 7	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 976
+# parallel_id = hk/976
 # text = 我希望主席裁決。
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	希望	希望	VERB	_	_	0	root	_	SpaceAfter=No
@@ -16378,6 +17354,7 @@
 5	。	。	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 977
+# parallel_id = hk/977
 # text = 請呢五位議員返返去個席位嗰度，因為立法會《議事規則》……
 1	請	請	VERB	_	_	0	root	_	SpaceAfter=No
 2	呢	呢	DET	_	_	5	det	_	SpaceAfter=No
@@ -16400,6 +17377,7 @@
 19	……	……	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 978
+# parallel_id = hk/978
 # text = 嗱，剛才呢，個個會議進程呢，係非常之好嘅……
 1	嗱	嗱	INTJ	_	_	15	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -16420,6 +17398,7 @@
 17	……	……	PUNCT	_	_	15	punct	_	SpaceAfter=No
 
 # sent_id = 979
+# parallel_id = hk/979
 # text = 即係第四十二條講得好清楚……
 1	即	即	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	係	係	VERB	_	_	0	root	_	SpaceAfter=No
@@ -16432,6 +17411,7 @@
 9	……	……	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 980
+# parallel_id = hk/980
 # text = 係祇係你哋呢，係提出呢啲噉嘅問題出嚟呢，會議先唔能夠進行。
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	祇	祇	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -16457,6 +17437,7 @@
 22	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 981
+# parallel_id = hk/981
 # text = 主席，我希望你叫返嗰五位議員返去佢嘅席位，好……
 1	主席	主席	NOUN	_	_	4	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -16478,6 +17459,7 @@
 18	……	……	PUNCT	_	_	4	punct	_	SpaceAfter=No
 
 # sent_id = 982
+# parallel_id = hk/982
 # text = 我想同你講聲，我未曾叫梁美芬議員你發言嘅。
 1	我	我	PRON	_	_	5	nsubj	_	SpaceAfter=No
 2	想	想	AUX	_	_	5	aux	_	SpaceAfter=No
@@ -16497,6 +17479,7 @@
 16	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 983
+# parallel_id = hk/983
 # text = 請你坐低先，唔該你。
 1	請	請	VERB	_	_	0	root	_	SpaceAfter=No
 2	你	你	PRON	_	_	1	obj	_	SpaceAfter=No
@@ -16509,6 +17492,7 @@
 9	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 984
+# parallel_id = hk/984
 # text = 下一位呢，就係陳直-陳志全議員。
 1	下	下	DET	_	_	3	det	_	SpaceAfter=No
 2	一	一	NUM	_	_	3	nummod	_	SpaceAfter=No
@@ -16524,6 +17508,7 @@
 12	。	。	PUNCT	_	_	10	punct	_	SpaceAfter=No
 
 # sent_id = 985
+# parallel_id = hk/985
 # text = 佢未完個……
 1	佢	佢	PRON	_	_	3	nsubj	_	SpaceAfter=No
 2	未	未	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -16532,6 +17517,7 @@
 5	……	……	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 986
+# parallel_id = hk/986
 # text = 你頭先……你坐低咗。
 1	你	你	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	頭先	頭先	NOUN	_	_	0	root	_	SpaceAfter=No
@@ -16543,6 +17529,7 @@
 8	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 987
+# parallel_id = hk/987
 # text = 我以為你發完……我問咗你有冇發言嘑，好，你發-你發言啦！
 1	我	我	PRON	_	_	2	nsubj	_	SpaceAfter=No
 2	以為	以為	VERB	_	_	0	root	_	SpaceAfter=No
@@ -16570,6 +17557,7 @@
 24	！	！	PUNCT	_	_	2	punct	_	SpaceAfter=No
 
 # sent_id = 988
+# parallel_id = hk/988
 # text = 繼續啦，你！
 1	繼續	繼續	VERB	_	_	0	root	_	SpaceAfter=No
 2	啦	喇	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -16578,6 +17566,7 @@
 5	！	！	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 989
+# parallel_id = hk/989
 # text = 主席呀，我-我唔記得咗我講到邊呀。
 1	主席	主席	NOUN	_	_	8	vocative	_	SpaceAfter=No
 2	呀	呀	PART	_	_	1	discourse:sp	_	SpaceAfter=No
@@ -16596,6 +17585,7 @@
 15	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 990
+# parallel_id = hk/990
 # text = 頭先比較混亂。
 1	頭先	頭先	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No
 2	比較	比較	ADV	_	_	3	advmod	_	SpaceAfter=No
@@ -16603,6 +17593,7 @@
 4	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 991
+# parallel_id = hk/991
 # text = 誒，其實呢，喺個選舉裏便……
 1	誒	誒	INTJ	_	_	6	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -16616,6 +17607,7 @@
 10	……	……	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 992
+# parallel_id = hk/992
 # text = 唔該你坐低，唔該你坐低，唔該你坐低。
 1	唔該	唔該	VERB	_	_	0	root	_	SpaceAfter=No
 2	你	你	PRON	_	_	1	obj	_	SpaceAfter=No
@@ -16634,6 +17626,7 @@
 15	。	。	PUNCT	_	_	1	punct	_	SpaceAfter=No
 
 # sent_id = 993
+# parallel_id = hk/993
 # text = 未叫你發言嗰陣時，唔該你坐低。
 1	未	未	ADV	_	_	2	advmod	_	SpaceAfter=No
 2	叫	叫	VERB	_	_	7	advcl	_	SpaceAfter=No
@@ -16648,6 +17641,7 @@
 11	。	。	PUNCT	_	_	7	punct	_	SpaceAfter=No
 
 # sent_id = 994
+# parallel_id = hk/994
 # text = 梁頌恆，請你繼續發言。
 1	梁頌恆	梁頌恆	PROPN	_	_	3	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	3	punct	_	SpaceAfter=No
@@ -16658,6 +17652,7 @@
 7	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 995
+# parallel_id = hk/995
 # text = 主席，任何，一個選舉裏便，最重要嘅兩樣嘢，就是候選人嘅資格，與及選民嘅基礎。
 1	主席	主席	NOUN	_	_	21	vocative	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -16688,6 +17683,7 @@
 27	。	。	PUNCT	_	_	21	punct	_	SpaceAfter=No
 
 # sent_id = 996
+# parallel_id = hk/996
 # text = 今日，我哋呢度發生咗兩個問題。
 1	今日	今日	NOUN	_	_	5	obl:tmod	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	5	punct	_	SpaceAfter=No
@@ -16701,6 +17697,7 @@
 10	。	。	PUNCT	_	_	5	punct	_	SpaceAfter=No
 
 # sent_id = 997
+# parallel_id = hk/997
 # text = 第一，我哋候選人嘅資格，係成疑嘅。
 1	第一	第一	ADJ	_	_	9	advmod	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -16715,6 +17712,7 @@
 11	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 998
+# parallel_id = hk/998
 # text = 頭先，有好多議員講咗我呢點，我唔詳述。
 1	頭先	頭先	NOUN	_	_	3	obl:tmod	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -16733,6 +17731,7 @@
 15	。	。	PUNCT	_	_	3	punct	_	SpaceAfter=No
 
 # sent_id = 999
+# parallel_id = hk/999
 # text = 第二點，負責選-投票嘅人嘅資格，喺之前，《議事規則》上一項嗰度，根本就未完成。
 1	第二	第二	ADJ	_	_	28	amod	_	SpaceAfter=No
 2	點	點	NOUN	_	NounType=Clf	28	obl	_	SpaceAfter=No
@@ -16765,6 +17764,7 @@
 29	。	。	PUNCT	_	_	28	punct	_	SpaceAfter=No
 
 # sent_id = 1000
+# parallel_id = hk/1000
 # text = 噉，我哋又點樣去開始下一步，呢一個選主席嘅呢一個會議呢？
 1	噉	噉	ADV	_	_	6	discourse	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -16791,6 +17791,7 @@
 23	？	？	PUNCT	_	_	6	punct	_	SpaceAfter=No
 
 # sent_id = 1001
+# parallel_id = hk/1001
 # text = 選-《議事規則》裏便，係有清楚-講到明，我哋呢一個，由宣誓去到選主席嘅程序。
 1	選	選	VERB	_	_	5	reparandum	_	SpaceAfter=No
 2	-	-	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -16823,6 +17824,7 @@
 29	。	。	PUNCT	_	_	9	punct	_	SpaceAfter=No
 
 # sent_id = 1002
+# parallel_id = hk/1002
 # text = 喺第十二則，每屆任期嘅首次會議嗰度係有清晰列明。
 1	喺	喺	ADP	_	_	3	case	_	SpaceAfter=No
 2	第十二	第十二	ADJ	_	_	3	amod	_	SpaceAfter=No
@@ -16844,6 +17846,7 @@
 18	。	。	PUNCT	_	_	13	punct	_	SpaceAfter=No
 
 # sent_id = 1003
+# parallel_id = hk/1003
 # text = 所以，主席，首先你要去望一望呢一個sh-《議事規則》裏便嘅資料，去決定返我哋先後次序。
 1	所以	所以	ADV	_	_	8	advmod	_	SpaceAfter=No
 2	，	，	PUNCT	_	_	1	punct	_	SpaceAfter=No
@@ -16876,6 +17879,7 @@
 29	。	。	PUNCT	_	_	8	punct	_	SpaceAfter=No
 
 # sent_id = 1004
+# parallel_id = hk/1004
 # text = 係要畀每一個議員，出席咗會議嘅議員，去作出咗呢個宗教式，或者非宗教式宣誓後，再按照呢個《議事規則》第四條呢，先去進行選，主席呢一個程序。
 1	係	係	VERB	_	_	0	root	_	SpaceAfter=No
 2	要	要	AUX	_	_	3	aux	_	SpaceAfter=No


### PR DESCRIPTION
- update README metadata and add parallel IDs
     - add "Parallel: "hk" to indicate parallel data availability
- add " parallel_id = hk/{n}/part{n} alt{n}" format to support automated parallel sentences identification, where n = any number (positive intergers, arabic numerals, starts with 1)